### PR TITLE
Adding Pages/Resources/Widgets/RelationManagers to Module Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,22 @@ If you would like to change the path, you can change it under the corresponding 
 ### The Context's Service Provider
 This package automatically adds each of the generated context's service provider in providers' list in `app.php config`. Be sure to remove this Service Provider in case you delete the context.
 
-## Adding Pages/Resources to Module Context
+## Adding Pages/Resources/Widgets/RelationManagers to Module Context
 
-You may now add filament resources in your FilamentTeams directories. Generate Filament pages/resources/widgets as you normally would. Move them into the context-folder
-and update the namespace. TODO: We will write a command to automatically generate the resources and pages easily.
+You may now add filament resources in your FilamentTeams directories. 
+```bash
+#Page: Pass the Module name as an argument and the name of page.
+php artisan module:make-filament-page {module?} {name?} {--R|resource=} {--T|type=} {--F|force}
+
+#Resources: Pass the Module name as an argument and the name of resources.
+php artisan module:make-filament-resource {module?} {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--F|force}
+
+#Widgets: Pass the Module name as an argument and the name of widget.
+php artisan module:make-filament-widget {module?} {name?} {--R|resource=} {--C|chart} {--T|table} {--S|stats-overview} {--F|force}
+
+#RelationManagers: Pass the Module name as an argument and the name of RelationManager.
+php artisan module:make-filament-relation-manager {module?} {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--F|force}
+```
 
 ### ContextualPage & ContextualResource traits
 

--- a/src/Commands/FilamentModuleMakePageCommand.php
+++ b/src/Commands/FilamentModuleMakePageCommand.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Savannabits\FilamentModules\Commands;
+
+use Filament\Commands\MakePageCommand;
+use Filament\Support\Commands\Concerns\CanManipulateFiles;
+use Filament\Support\Commands\Concerns\CanValidateInput;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+use Nwidart\Modules\Module;
+
+class FilamentModuleMakePageCommand extends MakePageCommand
+{
+
+    use ModuleCommandTrait;
+
+    protected $description = 'Creates a Filament page class and view.';
+
+    protected $signature = 'module:make-filament-page {module?} {name?} {--R|resource=} {--T|type=} {--F|force}';
+
+    protected ?Module $module;
+
+    public function handle(): int
+    {
+        $module = (string) Str::of($this->argument('module') ?? $this->askRequired('Module Name (e.g. `sales`)', 'module'));
+        $this->module = app('modules')->findOrFail($this->getModuleName());
+        $path = module_path($module, 'Filament/Pages/') ;
+        $resourcePath = module_path($module,'Filament/Resources/');
+        $namespace = $this->getModuleNamespace().'\\Filament\\Pages';
+        $resourceNamespace = $this->getModuleNamespace().'\\Filament\\Resources';
+
+        $page = (string) Str::of($this->argument('name') ?? $this->askRequired('Name (e.g. `Settings`)', 'name'))
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->replace('/', '\\');
+        $pageClass = (string) Str::of($page)->afterLast('\\');
+        $pageNamespace = Str::of($page)->contains('\\') ?
+            (string) Str::of($page)->beforeLast('\\') :
+            '';
+
+        $resource = null;
+        $resourceClass = null;
+        $resourcePage = null;
+
+        $resourceInput = $this->option('resource') ?? $this->ask('(Optional) Resource (e.g. `UserResource`)');
+
+        if ($resourceInput !== null) {
+            $resource = (string) Str::of($resourceInput)
+                ->studly()
+                ->trim('/')
+                ->trim('\\')
+                ->trim(' ')
+                ->replace('/', '\\');
+
+            if (! Str::of($resource)->endsWith('Resource')) {
+                $resource .= 'Resource';
+            }
+
+            $resourceClass = (string) Str::of($resource)
+                ->afterLast('\\');
+
+            $resourcePage = $this->option('type') ?? $this->choice(
+                'Which type of page would you like to create?',
+                [
+                    'custom' => 'Custom',
+                    'ListRecords' => 'List',
+                    'CreateRecord' => 'Create',
+                    'EditRecord' => 'Edit',
+                    'ViewRecord' => 'View',
+                    'ManageRecords' => 'Manage',
+                ],
+                'custom',
+            );
+        }
+
+        $view = Str::of($page)
+            ->prepend(
+                (string) Str::of($resource === null ? "{$namespace}\\" : "{$resourceNamespace}\\{$resource}\\pages\\")
+                    ->replace($this->getModuleNamespace(), '')
+            )
+            ->replace('\\', '/')
+            ->replaceFirst('/','')
+            ->explode('/')
+            ->map(fn ($segment) => Str::lower(Str::kebab($segment)))
+            ->implode('.');
+
+        $path = (string) Str::of($page)
+            ->prepend('/')
+            ->prepend($resource === null ? $path : "{$resourcePath}\\{$resource}\\Pages\\")
+            ->replace('\\', '/')
+            ->replace('//', '/')
+            ->append('.php');
+
+        $viewPath = module_path($module, 'Resources/'. (string) Str::of($view)
+        ->replace('.', '/')
+        ->prepend('views/')
+        ->append('.blade.php'));
+
+        $files = array_merge(
+            [$path],
+            $resourcePage === 'custom' ? [$viewPath] : [],
+        );
+
+        if (! $this->option('force') && $this->checkForCollision($files)) {
+            return static::INVALID;
+        }
+
+        if ($resource === null) {
+            $this->copyStubToApp('Page', $path, [
+                'class' => $pageClass,
+                'namespace' => $namespace . ($pageNamespace !== '' ? "\\{$pageNamespace}" : ''),
+                'view' =>  $this->module->getLowerName().'::'.$view,
+            ]);
+        } else {
+            $this->copyStubToApp($resourcePage === 'custom' ? 'CustomResourcePage' : 'ResourcePage', $path, [
+                'baseResourcePage' => 'Filament\\Resources\\Pages\\' . ($resourcePage === 'custom' ? 'Page' : $resourcePage),
+                'baseResourcePageClass' => $resourcePage === 'custom' ? 'Page' : $resourcePage,
+                'namespace' => "{$resourceNamespace}\\{$resource}\\Pages" . ($pageNamespace !== '' ? "\\{$pageNamespace}" : ''),
+                'resource' => "{$resourceNamespace}\\{$resource}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $pageClass,
+                'view' => $this->module->getLowerName().'::'.$view,
+            ]);
+        }
+
+        if ($resource === null || $resourcePage === 'custom') {
+            $this->copyStubToApp('PageView', $viewPath);
+        }
+
+        $this->info("Successfully created {$page}!");
+
+        if ($resource !== null) {
+            $this->info("Make sure to register the page in `{$resourceClass}::getPages()`.");
+        }
+
+        return static::SUCCESS;
+    }
+
+    public function getModuleNamespace()
+    {
+        return $this->laravel['modules']->config('namespace').'\\'.$this->getModuleName();
+    }
+
+
+
+}

--- a/src/Commands/FilamentModuleMakeRelationManagerCommand.php
+++ b/src/Commands/FilamentModuleMakeRelationManagerCommand.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Savannabits\FilamentModules\Commands;
+
+use Filament\Commands\MakeRelationManagerCommand;
+use Illuminate\Support\Str;
+use Nwidart\Modules\Module;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+
+class FilamentModuleMakeRelationManagerCommand extends MakeRelationManagerCommand
+{
+    use ModuleCommandTrait;
+
+
+    protected $description = 'Creates a Filament relation manager class for a resource.';
+
+    protected $signature = 'module:make-filament-relation-manager {module?} {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--F|force}';
+
+    protected ?Module $module;
+
+    public function handle(): int
+    {
+        $module = (string) Str::of($this->argument('module') ?? $this->askRequired('Module Name (e.g. `sales`)', 'module'));
+        $this->module = app('modules')->findOrFail($this->getModuleName());
+
+        $resourcePath = module_path($module,'Filament/Resources/');
+        $resourceNamespace = $this->getModuleNamespace().'\\Filament\\Resources';
+
+        $resource = (string) Str::of($this->argument('resource') ?? $this->askRequired('Resource (e.g. `DepartmentResource`)', 'resource'))
+            ->studly()
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->replace('/', '\\');
+
+        if (! Str::of($resource)->endsWith('Resource')) {
+            $resource .= 'Resource';
+        }
+
+        $relationship = (string) Str::of($this->argument('relationship') ?? $this->askRequired('Relationship (e.g. `members`)', 'relationship'))
+            ->trim(' ');
+        $managerClass = (string) Str::of($relationship)
+            ->studly()
+            ->append('RelationManager');
+
+        $recordTitleAttribute = (string) Str::of($this->argument('recordTitleAttribute') ?? $this->askRequired('Title attribute (e.g. `name`)', 'title attribute'))
+            ->trim(' ');
+
+        $path = (string) Str::of($managerClass)
+            ->prepend("{$resourcePath}/{$resource}/RelationManagers/")
+            ->replace('\\', '/')
+            ->append('.php');
+
+        if (! $this->option('force') && $this->checkForCollision([
+            $path,
+        ])) {
+            return static::INVALID;
+        }
+
+        $tableHeaderActions = [];
+
+        $tableHeaderActions[] = 'Tables\Actions\CreateAction::make(),';
+
+        if ($this->option('associate')) {
+            $tableHeaderActions[] = 'Tables\Actions\AssociateAction::make(),';
+        }
+
+        if ($this->option('attach')) {
+            $tableHeaderActions[] = 'Tables\Actions\AttachAction::make(),';
+        }
+
+        $tableHeaderActions = implode(PHP_EOL, $tableHeaderActions);
+
+        $tableActions = [];
+
+        if ($this->option('view')) {
+            $tableActions[] = 'Tables\Actions\ViewAction::make(),';
+        }
+
+        $tableActions[] = 'Tables\Actions\EditAction::make(),';
+
+        if ($this->option('associate')) {
+            $tableActions[] = 'Tables\Actions\DissociateAction::make(),';
+        }
+
+        if ($this->option('attach')) {
+            $tableActions[] = 'Tables\Actions\DetachAction::make(),';
+        }
+
+        $tableActions[] = 'Tables\Actions\DeleteAction::make(),';
+
+        if ($this->option('soft-deletes')) {
+            $tableActions[] = 'Tables\Actions\ForceDeleteAction::make(),';
+            $tableActions[] = 'Tables\Actions\RestoreAction::make(),';
+        }
+
+        $tableActions = implode(PHP_EOL, $tableActions);
+
+        $tableBulkActions = [];
+
+        if ($this->option('associate')) {
+            $tableBulkActions[] = 'Tables\Actions\DissociateBulkAction::make(),';
+        }
+
+        if ($this->option('attach')) {
+            $tableBulkActions[] = 'Tables\Actions\DetachBulkAction::make(),';
+        }
+
+        $tableBulkActions[] = 'Tables\Actions\DeleteBulkAction::make(),';
+
+        $eloquentQuery = '';
+
+        if ($this->option('soft-deletes')) {
+            $tableBulkActions[] = 'Tables\Actions\RestoreBulkAction::make(),';
+            $tableBulkActions[] = 'Tables\Actions\ForceDeleteBulkAction::make(),';
+
+            $eloquentQuery .= PHP_EOL . PHP_EOL . 'protected function getTableQuery(): Builder';
+            $eloquentQuery .= PHP_EOL . '{';
+            $eloquentQuery .= PHP_EOL . '    return parent::getTableQuery()';
+            $eloquentQuery .= PHP_EOL . '        ->withoutGlobalScopes([';
+            $eloquentQuery .= PHP_EOL . '            SoftDeletingScope::class,';
+            $eloquentQuery .= PHP_EOL . '        ]);';
+            $eloquentQuery .= PHP_EOL . '}';
+        }
+
+        $tableBulkActions = implode(PHP_EOL, $tableBulkActions);
+
+        $this->copyStubToApp('RelationManager', $path, [
+            'eloquentQuery' => $this->indentString($eloquentQuery, 1),
+            'namespace' => "{$resourceNamespace}\\{$resource}\\RelationManagers",
+            'managerClass' => $managerClass,
+            'recordTitleAttribute' => $recordTitleAttribute,
+            'relationship' => $relationship,
+            'tableActions' => $this->indentString($tableActions, 4),
+            'tableBulkActions' => $this->indentString($tableBulkActions, 4),
+            'tableFilters' => $this->indentString(
+                $this->option('soft-deletes') ? 'Tables\Filters\TrashedFilter::make()' : '//',
+                4,
+            ),
+            'tableHeaderActions' => $this->indentString($tableHeaderActions, 4),
+        ]);
+
+        $this->info("Successfully created {$managerClass}!");
+
+        $this->info("Make sure to register the relation in `{$resource}::getRelations()`.");
+
+        return static::SUCCESS;
+    }
+
+    public function getModuleNamespace()
+    {
+        return $this->laravel['modules']->config('namespace').'\\'.$this->getModuleName();
+    }
+}

--- a/src/Commands/FilamentModuleMakeResourceCommand.php
+++ b/src/Commands/FilamentModuleMakeResourceCommand.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Savannabits\FilamentModules\Commands;
+
+use Filament\Commands\MakeResourceCommand;
+use Illuminate\Support\Str;
+use Nwidart\Modules\Module;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+
+class FilamentModuleMakeResourceCommand extends MakeResourceCommand
+{
+    use ModuleCommandTrait;
+
+
+    protected $description = 'Creates a Filament resource class and default page classes.';
+
+    protected $signature = 'module:make-filament-resource {module?} {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--F|force}';
+
+    protected ?Module $module;
+
+    public function handle(): int
+    {
+        $module = (string) Str::of($this->argument('module') ?? $this->askRequired('Module Name (e.g. `sales`)', 'module'));
+        $this->module = app('modules')->findOrFail($this->getModuleName());
+
+        $path = module_path($module, 'Filament/Resources/') ;
+        $namespace = $this->getModuleNamespace().'\\Filament\\Resources';
+
+        $model = (string) Str::of($this->argument('name') ?? $this->askRequired('Model (e.g. `BlogPost`)', 'name'))
+            ->studly()
+            ->beforeLast('Resource')
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->studly()
+            ->replace('/', '\\');
+
+        if (blank($model)) {
+            $model = 'Resource';
+        }
+
+        $modelClass = (string) Str::of($model)->afterLast('\\');
+        $modelNamespace = Str::of($model)->contains('\\') ?
+            (string) Str::of($model)->beforeLast('\\') :
+            '';
+        $pluralModelClass = (string) Str::of($modelClass)->pluralStudly();
+
+        $resource = "{$model}Resource";
+        $resourceClass = "{$modelClass}Resource";
+        $resourceNamespace = $modelNamespace;
+        $namespace .= $resourceNamespace !== '' ? "\\{$resourceNamespace}" : '';
+        $listResourcePageClass = "List{$pluralModelClass}";
+        $manageResourcePageClass = "Manage{$pluralModelClass}";
+        $createResourcePageClass = "Create{$modelClass}";
+        $editResourcePageClass = "Edit{$modelClass}";
+        $viewResourcePageClass = "View{$modelClass}";
+
+        $baseResourcePath =
+            (string) Str::of($resource)
+                ->prepend('/')
+                ->prepend($path)
+                ->replace('\\', '/')
+                ->replace('//', '/');
+
+        $resourcePath = "{$baseResourcePath}.php";
+        $resourcePagesDirectory = "{$baseResourcePath}/Pages";
+        $listResourcePagePath = "{$resourcePagesDirectory}/{$listResourcePageClass}.php";
+        $manageResourcePagePath = "{$resourcePagesDirectory}/{$manageResourcePageClass}.php";
+        $createResourcePagePath = "{$resourcePagesDirectory}/{$createResourcePageClass}.php";
+        $editResourcePagePath = "{$resourcePagesDirectory}/{$editResourcePageClass}.php";
+        $viewResourcePagePath = "{$resourcePagesDirectory}/{$viewResourcePageClass}.php";
+
+        if (! $this->option('force') && $this->checkForCollision([
+            $resourcePath,
+            $listResourcePagePath,
+            $manageResourcePagePath,
+            $createResourcePagePath,
+            $editResourcePagePath,
+            $viewResourcePagePath,
+        ])) {
+            return static::INVALID;
+        }
+
+        $pages = '';
+        $pages .= '\'index\' => Pages\\' . ($this->option('simple') ? $manageResourcePageClass : $listResourcePageClass) . '::route(\'/\'),';
+
+        if (! $this->option('simple')) {
+            $pages .= PHP_EOL . "'create' => Pages\\{$createResourcePageClass}::route('/create'),";
+
+            if ($this->option('view')) {
+                $pages .= PHP_EOL . "'view' => Pages\\{$viewResourcePageClass}::route('/{record}'),";
+            }
+
+            $pages .= PHP_EOL . "'edit' => Pages\\{$editResourcePageClass}::route('/{record}/edit'),";
+        }
+
+        $tableActions = [];
+
+        if ($this->option('view')) {
+            $tableActions[] = 'Tables\Actions\ViewAction::make(),';
+        }
+
+        $tableActions[] = 'Tables\Actions\EditAction::make(),';
+
+        $relations = '';
+
+        if ($this->option('simple')) {
+            $tableActions[] = 'Tables\Actions\DeleteAction::make(),';
+
+            if ($this->option('soft-deletes')) {
+                $tableActions[] = 'Tables\Actions\ForceDeleteAction::make(),';
+                $tableActions[] = 'Tables\Actions\RestoreAction::make(),';
+            }
+        } else {
+            $relations .= PHP_EOL . 'public static function getRelations(): array';
+            $relations .= PHP_EOL . '{';
+            $relations .= PHP_EOL . '    return [';
+            $relations .= PHP_EOL . '        //';
+            $relations .= PHP_EOL . '    ];';
+            $relations .= PHP_EOL . '}' . PHP_EOL;
+        }
+
+        $tableActions = implode(PHP_EOL, $tableActions);
+
+        $tableBulkActions = [];
+
+        $tableBulkActions[] = 'Tables\Actions\DeleteBulkAction::make(),';
+
+        $eloquentQuery = '';
+
+        if ($this->option('soft-deletes')) {
+            $tableBulkActions[] = 'Tables\Actions\ForceDeleteBulkAction::make(),';
+            $tableBulkActions[] = 'Tables\Actions\RestoreBulkAction::make(),';
+
+            $eloquentQuery .= PHP_EOL . PHP_EOL . 'public static function getEloquentQuery(): Builder';
+            $eloquentQuery .= PHP_EOL . '{';
+            $eloquentQuery .= PHP_EOL . '    return parent::getEloquentQuery()';
+            $eloquentQuery .= PHP_EOL . '        ->withoutGlobalScopes([';
+            $eloquentQuery .= PHP_EOL . '            SoftDeletingScope::class,';
+            $eloquentQuery .= PHP_EOL . '        ]);';
+            $eloquentQuery .= PHP_EOL . '}';
+        }
+
+        $tableBulkActions = implode(PHP_EOL, $tableBulkActions);
+
+        $this->copyStubToApp('Resource', $resourcePath, [
+            'eloquentQuery' => $this->indentString($eloquentQuery, 1),
+            'formSchema' => $this->indentString($this->option('generate') ? $this->getResourceFormSchema(
+                'App\\Models' . ($modelNamespace !== '' ? "\\{$modelNamespace}" : '') . '\\' . $modelClass,
+            ) : '//', 4),
+            'model' => $model === 'Resource' ? 'Resource as ResourceModel' : $model,
+            'modelClass' => $model === 'Resource' ? 'ResourceModel' : $modelClass,
+            'namespace' => $namespace,
+            'pages' => $this->indentString($pages, 3),
+            'relations' => $this->indentString($relations, 1),
+            'resource' => "{$namespace}\\{$resourceClass}",
+            'resourceClass' => $resourceClass,
+            'tableActions' => $this->indentString($tableActions, 4),
+            'tableBulkActions' => $this->indentString($tableBulkActions, 4),
+            'tableColumns' => $this->indentString($this->option('generate') ? $this->getResourceTableColumns(
+                'App\Models' . ($modelNamespace !== '' ? "\\{$modelNamespace}" : '') . '\\' . $modelClass,
+            ) : '//', 4),
+            'tableFilters' => $this->indentString(
+                $this->option('soft-deletes') ? 'Tables\Filters\TrashedFilter::make(),' : '//',
+                4,
+            ),
+        ]);
+
+        if ($this->option('simple')) {
+            $this->copyStubToApp('ResourceManagePage', $manageResourcePagePath, [
+                'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                'resource' => "{$namespace}\\{$resourceClass}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $manageResourcePageClass,
+            ]);
+        } else {
+            $this->copyStubToApp('ResourceListPage', $listResourcePagePath, [
+                'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                'resource' => "{$namespace}\\{$resourceClass}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $listResourcePageClass,
+            ]);
+
+            $this->copyStubToApp('ResourcePage', $createResourcePagePath, [
+                'baseResourcePage' => 'Filament\\Resources\\Pages\\CreateRecord',
+                'baseResourcePageClass' => 'CreateRecord',
+                'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                'resource' => "{$namespace}\\{$resourceClass}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $createResourcePageClass,
+            ]);
+
+            $editPageActions = [];
+
+            if ($this->option('view')) {
+                $this->copyStubToApp('ResourceViewPage', $viewResourcePagePath, [
+                    'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                    'resource' => "{$namespace}\\{$resourceClass}",
+                    'resourceClass' => $resourceClass,
+                    'resourcePageClass' => $viewResourcePageClass,
+                ]);
+
+                $editPageActions[] = 'Actions\ViewAction::make(),';
+            }
+
+            $editPageActions[] = 'Actions\DeleteAction::make(),';
+
+            if ($this->option('soft-deletes')) {
+                $editPageActions[] = 'Actions\ForceDeleteAction::make(),';
+                $editPageActions[] = 'Actions\RestoreAction::make(),';
+            }
+
+            $editPageActions = implode(PHP_EOL, $editPageActions);
+
+            $this->copyStubToApp('ResourceEditPage', $editResourcePagePath, [
+                'actions' => $this->indentString($editPageActions, 3),
+                'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
+                'resource' => "{$namespace}\\{$resourceClass}",
+                'resourceClass' => $resourceClass,
+                'resourcePageClass' => $editResourcePageClass,
+            ]);
+        }
+
+        $this->info("Successfully created {$resource}!");
+
+        return static::SUCCESS;
+    }
+
+    public function getModuleNamespace()
+    {
+        return $this->laravel['modules']->config('namespace').'\\'.$this->getModuleName();
+    }
+}

--- a/src/Commands/FilamentModuleMakeWidgetCommand.php
+++ b/src/Commands/FilamentModuleMakeWidgetCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Savannabits\FilamentModules\Commands;
+
+use Filament\Commands\MakeWidgetCommand;
+use Illuminate\Support\Str;
+use Nwidart\Modules\Module;
+use Nwidart\Modules\Traits\ModuleCommandTrait;
+
+class FilamentModuleMakeWidgetCommand extends MakeWidgetCommand
+{
+    use ModuleCommandTrait;
+
+
+    protected $description = 'Creates a Filament widget class.';
+
+    protected $signature = 'module:make-filament-widget {module?} {name?} {--R|resource=} {--C|chart} {--T|table} {--S|stats-overview} {--F|force}';
+
+    protected ?Module $module;
+
+    public function handle(): int
+    {
+        $module = (string) Str::of($this->argument('module') ?? $this->askRequired('Module Name (e.g. `sales`)', 'module'));
+        $this->module = app('modules')->findOrFail($this->getModuleName());
+        $path = module_path($module, 'Filament/Widgets/') ;
+        $resourcePath = module_path($module,'Filament/Resources/');
+        $namespace = $this->getModuleNamespace().'\\Filament\\Widgets';
+        $resourceNamespace = $this->getModuleNamespace().'\\Filament\\Resources';
+
+        $widget = (string) Str::of($this->argument('name') ?? $this->askRequired('Name (e.g. `BlogPostsChart`)', 'name'))
+            ->trim('/')
+            ->trim('\\')
+            ->trim(' ')
+            ->replace('/', '\\');
+        $widgetClass = (string) Str::of($widget)->afterLast('\\');
+        $widgetNamespace = Str::of($widget)->contains('\\') ?
+            (string) Str::of($widget)->beforeLast('\\') :
+            '';
+
+        $resource = null;
+        $resourceClass = null;
+
+        $resourceInput = $this->option('resource') ?? $this->ask('(Optional) Resource (e.g. `BlogPostResource`)');
+
+        if ($resourceInput !== null) {
+            $resource = (string) Str::of($resourceInput)
+                ->studly()
+                ->trim('/')
+                ->trim('\\')
+                ->trim(' ')
+                ->replace('/', '\\');
+
+            if (! Str::of($resource)->endsWith('Resource')) {
+                $resource .= 'Resource';
+            }
+
+            $resourceClass = (string) Str::of($resource)
+                ->afterLast('\\');
+        }
+
+        $view = Str::of($widget)->prepend(
+            (string) Str::of($resource === null ? "{$namespace}\\" : "{$resourceNamespace}\\{$resource}\\widgets\\")
+            ->replace($this->getModuleNamespace(), '')
+        )
+            ->replace('\\', '/')
+            ->replaceFirst('/','')
+            ->explode('/')
+            ->map(fn ($segment) => Str::lower(Str::kebab($segment)))
+            ->implode('.');
+
+        $path = (string) Str::of($widget)
+            ->prepend('/')
+            ->prepend($resource === null ? $path : "{$resourcePath}\\{$resource}\\Widgets\\")
+            ->replace('\\', '/')
+            ->replace('//', '/')
+            ->append('.php');
+
+            $viewPath = module_path($module, 'Resources/'. (string) Str::of($view)
+            ->replace('.', '/')
+            ->prepend('views/')
+            ->append('.blade.php'));
+
+        if (! $this->option('force') && $this->checkForCollision([
+            $path,
+            ($this->option('stats-overview') || $this->option('chart')) ?: $viewPath,
+        ])) {
+            return static::INVALID;
+        }
+
+        if ($this->option('chart')) {
+            $chart = $this->choice(
+                'Chart type',
+                [
+                    'Bar chart',
+                    'Bubble chart',
+                    'Doughnut chart',
+                    'Line chart',
+                    'Pie chart',
+                    'Polar area chart',
+                    'Radar chart',
+                    'Scatter chart',
+                ],
+            );
+
+            $this->copyStubToApp('ChartWidget', $path, [
+                'class' => $widgetClass,
+                'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
+                'chart' => Str::studly($chart),
+            ]);
+        } elseif ($this->option('table')) {
+            $this->copyStubToApp('TableWidget', $path, [
+                'class' => $widgetClass,
+                'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
+            ]);
+        } elseif ($this->option('stats-overview')) {
+            $this->copyStubToApp('StatsOverviewWidget', $path, [
+                'class' => $widgetClass,
+                'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
+            ]);
+        } else {
+            $this->copyStubToApp('Widget', $path, [
+                'class' => $widgetClass,
+                'namespace' => filled($resource) ? "{$resourceNamespace}\\{$resource}\\Widgets" . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : '') : $namespace . ($widgetNamespace !== '' ? "\\{$widgetNamespace}" : ''),
+                'view' =>  $this->module->getLowerName().'::'.$view,
+            ]);
+
+            $this->copyStubToApp('WidgetView', $viewPath);
+        }
+
+        $this->info("Successfully created {$widget}!");
+
+        if ($resource !== null) {
+            $this->info("Make sure to register the widget in `{$resourceClass}::getWidgets()`, and then again in `getHeaderWidgets()` or `getFooterWidgets()` of any `{$resourceClass}` page.");
+        }
+
+        return static::SUCCESS;
+    }
+
+    public function getModuleNamespace()
+    {
+        return $this->laravel['modules']->config('namespace').'\\'.$this->getModuleName();
+    }
+}

--- a/src/FilamentModulesServiceProvider.php
+++ b/src/FilamentModulesServiceProvider.php
@@ -6,6 +6,10 @@ use Filament\PluginServiceProvider;
 use Livewire\Livewire;
 use Savannabits\FilamentModules\Commands\FilamentGuardCommand;
 use Savannabits\FilamentModules\Commands\FilamentModuleCommand;
+use Savannabits\FilamentModules\Commands\FilamentModuleMakePageCommand;
+use Savannabits\FilamentModules\Commands\FilamentModuleMakeRelationManagerCommand;
+use Savannabits\FilamentModules\Commands\FilamentModuleMakeResourceCommand;
+use Savannabits\FilamentModules\Commands\FilamentModuleMakeWidgetCommand;
 use Savannabits\FilamentModules\Http\Middleware\ApplyContext;
 use Spatie\LaravelPackageTools\Package;
 
@@ -44,6 +48,10 @@ class FilamentModulesServiceProvider extends PluginServiceProvider
             ->hasCommands([
                 FilamentModuleCommand::class,
                 FilamentGuardCommand::class,
+                FilamentModuleMakePageCommand::class,
+                FilamentModuleMakeRelationManagerCommand::class,
+                FilamentModuleMakeResourceCommand::class,
+                FilamentModuleMakeWidgetCommand::class,
             ]);
     }
 

--- a/stubs/ChartWidget.stub
+++ b/stubs/ChartWidget.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Widgets\{{ chart }}Widget;
+
+class {{ class }} extends {{ chart }}Widget
+{
+    protected static ?string $heading = 'Chart';
+
+    protected function getData(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/stubs/CustomResourcePage.stub
+++ b/stubs/CustomResourcePage.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use {{ baseResourcePage }};
+
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected static string $view = '{{ view }}';
+}

--- a/stubs/Page.stub
+++ b/stubs/Page.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Pages\Page;
+use Savannabits\FilamentModules\Concerns\ContextualPage;
+
+class {{ class }} extends Page
+{
+    use ContextualPage;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static string $view = '{{ view }}';
+}

--- a/stubs/PageView.stub
+++ b/stubs/PageView.stub
@@ -1,0 +1,3 @@
+<x-filament::page>
+
+</x-filament::page>

--- a/stubs/RelationManager.stub
+++ b/stubs/RelationManager.stub
@@ -1,0 +1,48 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class {{ managerClass }} extends RelationManager
+{
+    protected static string $relationship = '{{ relationship }}';
+
+    protected static ?string $recordTitleAttribute = '{{ recordTitleAttribute }}';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('{{ recordTitleAttribute }}')
+                    ->required()
+                    ->maxLength(255),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('{{ recordTitleAttribute }}'),
+            ])
+            ->filters([
+{{ tableFilters }}
+            ])
+            ->headerActions([
+{{ tableHeaderActions }}
+            ])
+            ->actions([
+{{ tableActions }}
+            ])
+            ->bulkActions([
+{{ tableBulkActions }}
+            ]);
+    }{{ eloquentQuery }}
+}

--- a/stubs/Resource.stub
+++ b/stubs/Resource.stub
@@ -1,0 +1,56 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }}\Pages;
+use {{ resource }}\RelationManagers;
+use App\Models\{{ model }};
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Savannabits\FilamentModules\Concerns\ContextualResource;
+
+class {{ resourceClass }} extends Resource
+{
+    use ContextualResource;
+
+    protected static ?string $model = {{ modelClass }}::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-collection';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+{{ formSchema }}
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+{{ tableColumns }}
+            ])
+            ->filters([
+{{ tableFilters }}
+            ])
+            ->actions([
+{{ tableActions }}
+            ])
+            ->bulkActions([
+{{ tableBulkActions }}
+            ]);
+    }
+{{ relations }}
+    public static function getPages(): array
+    {
+        return [
+{{ pages }}
+        ];
+    }{{ eloquentQuery }}
+}

--- a/stubs/ResourceEditPage.stub
+++ b/stubs/ResourceEditPage.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class {{ resourcePageClass }} extends EditRecord
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getActions(): array
+    {
+        return [
+{{ actions }}
+        ];
+    }
+}

--- a/stubs/ResourceListPage.stub
+++ b/stubs/ResourceListPage.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class {{ resourcePageClass }} extends ListRecords
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/stubs/ResourceManagePage.stub
+++ b/stubs/ResourceManagePage.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ManageRecords;
+
+class {{ resourcePageClass }} extends ManageRecords
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/stubs/ResourcePage.stub
+++ b/stubs/ResourcePage.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Pages\Actions;
+use {{ baseResourcePage }};
+
+class {{ resourcePageClass }} extends {{ baseResourcePageClass }}
+{
+    protected static string $resource = {{ resourceClass }}::class;
+}

--- a/stubs/ResourceViewPage.stub
+++ b/stubs/ResourceViewPage.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ resource }};
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class {{ resourcePageClass }} extends ViewRecord
+{
+    protected static string $resource = {{ resourceClass }}::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/stubs/StatsOverviewWidget.stub
+++ b/stubs/StatsOverviewWidget.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Card;
+
+class {{ class }} extends BaseWidget
+{
+    protected function getCards(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/stubs/TableWidget.stub
+++ b/stubs/TableWidget.stub
@@ -1,0 +1,23 @@
+<?php
+
+namespace {{ namespace }};
+
+use Closure;
+use Filament\Tables;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+
+class {{ class }} extends BaseWidget
+{
+    protected function getTableQuery(): Builder
+    {
+        // ...
+    }
+
+    protected function getTableColumns(): array
+    {
+        return [
+            // ...
+        ];
+    }
+}

--- a/stubs/Widget.stub
+++ b/stubs/Widget.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Widgets\Widget;
+
+class {{ class }} extends Widget
+{
+    protected static string $view = '{{ view }}';
+}

--- a/stubs/WidgetView.stub
+++ b/stubs/WidgetView.stub
@@ -1,0 +1,5 @@
+<x-filament::widget>
+    <x-filament::card>
+        {{-- Widget content --}}
+    </x-filament::card>
+</x-filament::widget>


### PR DESCRIPTION
You may now add filament resources in your FilamentTeams directories. 
```bash
#Page: Pass the Module name as an argument and the name of page.
php artisan module:make-filament-page {module?} {name?} {--R|resource=} {--T|type=} {--F|force}

#Resources: Pass the Module name as an argument and the name of resources.
php artisan module:make-filament-resource {module?} {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--F|force}

#Widgets: Pass the Module name as an argument and the name of widget.
php artisan module:make-filament-widget {module?} {name?} {--R|resource=} {--C|chart} {--T|table} {--S|stats-overview} {--F|force}

#RelationManagers: Pass the Module name as an argument and the name of RelationManager.
php artisan module:make-filament-relation-manager {module?} {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--F|force}
```