### PR TITLE
Bug Fixes and Refactoring: Generation of additional Contexts in the same module is now working!

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,6 +1,10 @@
 name: Fix PHP code style issues
 
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   php-code-styling:

--- a/src/Commands/FilamentModuleCommand.php
+++ b/src/Commands/FilamentModuleCommand.php
@@ -35,7 +35,7 @@ class FilamentModuleCommand extends Command
         try {
             $this->module = app('modules')->findOrFail($this->getModuleName());
         } catch (\Throwable $exception) {
-            \Log::info($exception->getMessage().' Creating It ...');
+            \Log::info($exception->getMessage() . ' Creating It ...');
             Artisan::call('module:make', ['name' => [$this->argument('module')]]);
             $this->module = app('modules')->findOrFail($this->getModuleName());
         }
@@ -44,7 +44,7 @@ class FilamentModuleCommand extends Command
         $this->copyStubs($context);
 
         $this->createDirectories($context);
-
+        Artisan::call('module:make-filament-page', ['module' => $this->module->getName(), 'name' => 'Dashboard', 'context' => $context, '-n']);
         $this->info("Successfully created {$context} context!");
 
         if ($this->option('guard')) {
@@ -62,7 +62,7 @@ class FilamentModuleCommand extends Command
     protected function getContextInput(): string
     {
         return $this->validateInput(
-            fn () => $this->argument('module') ?? $this->askRequired('Module Name (e.g. `sales`)', 'module'),
+            fn() => $this->argument('module') ?? $this->askRequired('Module Name (e.g. `sales`)', 'module'),
             'module',
             ['required']
         );
@@ -92,7 +92,7 @@ class FilamentModuleCommand extends Command
 
     public function getModuleNamespace()
     {
-        return $this->laravel['modules']->config('namespace').'\\'.$this->getModuleName();
+        return $this->laravel['modules']->config('namespace') . '\\' . $this->getModuleName();
     }
 
     protected function copyStubs($context)
@@ -107,7 +107,7 @@ class FilamentModuleCommand extends Command
             ->append('.php');
 
         $configPath = $contextName
-            ->prepend($this->module->getLowerName().'-')
+            ->prepend($this->module->getLowerName() . '-')
             ->prepend('/')
             ->prepend(module_path($this->getModuleName(), 'Config'))
             ->append('.php');
@@ -118,21 +118,21 @@ class FilamentModuleCommand extends Command
             ->prepend('\\\\')
             ->prepend($moduleNs->replace('\\', '\\\\')->toString());
 
-        if (! $this->option('force') && $this->checkForCollision([
-            $serviceProviderPath,
-        ])) {
+        if (!$this->option('force') && $this->checkForCollision([
+                $serviceProviderPath,
+            ])) {
             return static::INVALID;
         }
 
-        if (! $this->option('force') && $this->checkForCollision([
-            $configPath,
-        ])) {
+        if (!$this->option('force') && $this->checkForCollision([
+                $configPath,
+            ])) {
             return static::INVALID;
         }
 
         $this->copyStubToApp('ContextServiceProvider', $serviceProviderPath, [
-            'class' => (string) $serviceProviderClass,
-            'name' => (string) $contextName,
+            'class' => (string)$serviceProviderClass,
+            'name' => (string)$contextName,
             'Module' => $this->module->getStudlyName(),
             'module' => $this->module->getLowerName(),
             'module_' => $this->module->getSnakeName(),
@@ -150,14 +150,14 @@ class FilamentModuleCommand extends Command
             ->prepend(module_path($this->getModuleName(), 'Http/Middleware/'))
             ->append('.php');
 
-        if (! $this->option('force') && $this->checkForCollision([$middlewarePath])) {
+        if (!$this->option('force') && $this->checkForCollision([$middlewarePath])) {
             return static::INVALID;
         }
 
         $middlewareNs = $moduleNs->append('\\Http\\\Middleware');
         $this->copyStubToApp('ContextMiddleware', $middlewarePath, [
-            'class' => (string) $middlewareClass,
-            'context' => (string) $contextName,
+            'class' => (string)$middlewareClass,
+            'context' => (string)$contextName,
             'module' => $this->module->getStudlyName(),
             'namespace' => $middlewareNs->replace('\\\\', '\\')->toString(),
         ]);
@@ -170,23 +170,23 @@ class FilamentModuleCommand extends Command
             ->prepend(module_path($this->getModuleName(), 'Http/Livewire/Auth/'))
             ->append('.php');
 
-        if (! $this->option('force') && $this->checkForCollision([$loginPath])) {
+        if (!$this->option('force') && $this->checkForCollision([$loginPath])) {
             return static::INVALID;
         }
 
         $loginNs = $moduleNs->append('\\Http\\Livewire\\Auth');
         $this->copyStubToApp('ContextLogin', $loginPath, [
-            'class' => (string) $loginClass,
-            'context' => (string) $contextName,
+            'class' => (string)$loginClass,
+            'context' => (string)$contextName,
             'module' => $this->module->getStudlyName(),
             'namespace' => $loginNs->replace('\\\\', '\\')->toString(),
         ]);
 
         // CONFIG
         $this->copyStubToApp('config', $configPath, [
-            'namespace' => (string) $contextNamespace,
+            'namespace' => (string)$contextNamespace,
             'moduleNamespace' => $moduleNs->replace('\\\\', '\\')->toString(),
-            'path' => (string) $context->replace('\\', '/'),
+            'path' => (string)$context->replace('\\', '/'),
             'loginClass' => $loginNs->append('\\')->append($loginClass)->append('::class')->replace('\\\\', '\\')->toString(),
             'authMiddleware' => $middlewareNs->append('\\')->append($middlewareClass)->append('::class')->replace('\\\\', '\\')->toString(),
             'module' => $this->module->getStudlyName(),
@@ -195,20 +195,20 @@ class FilamentModuleCommand extends Command
 
     protected function createDirectories($context)
     {
-        $directoryPath = module_path($this->getModuleName(), (string) $context->replace('\\', '/'));
+        $directoryPath = module_path($this->getModuleName(), (string)$context->replace('\\', '/'));
 
         app(Filesystem::class)->makeDirectory($directoryPath, force: $this->option('force'));
-        app(Filesystem::class)->makeDirectory($directoryPath.'/Pages', force: $this->option('force'));
-        app(Filesystem::class)->makeDirectory($directoryPath.'/Resources', force: $this->option('force'));
-        app(Filesystem::class)->makeDirectory($directoryPath.'/Widgets', force: $this->option('force'));
+        app(Filesystem::class)->makeDirectory($directoryPath . '/Pages', force: $this->option('force'));
+        app(Filesystem::class)->makeDirectory($directoryPath . '/Resources', force: $this->option('force'));
+        app(Filesystem::class)->makeDirectory($directoryPath . '/Widgets', force: $this->option('force'));
     }
 
     protected function copyStubToApp(string $stub, string $targetPath, array $replacements = []): void
     {
         $filesystem = app(Filesystem::class);
 
-        if (! $this->fileExists($stubPath = base_path("stubs/filament/{$stub}.stub"))) {
-            $stubPath = __DIR__."/../../stubs/{$stub}.stub";
+        if (!$this->fileExists($stubPath = base_path("stubs/filament/{$stub}.stub"))) {
+            $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
         }
 
         $stub = Str::of($filesystem->get($stubPath));
@@ -217,7 +217,7 @@ class FilamentModuleCommand extends Command
             $stub = $stub->replace("{{ {$key} }}", $replacement);
         }
 
-        $stub = (string) $stub;
+        $stub = (string)$stub;
 
         $this->writeFile($targetPath, $stub);
     }
@@ -225,14 +225,14 @@ class FilamentModuleCommand extends Command
     /**
      * Install the service provider in the application configuration file.
      *
-     * @param  string  $providerClass | Fully namespaced service class
+     * @param string $providerClass | Fully namespaced service class
      */
     protected function installServiceProvider(string $providerClass, string $after = 'RouteServiceProvider'): void
     {
-        if (! Str::contains($appConfig = file_get_contents(config_path('app.php')), $providerClass)) {
+        if (!Str::contains($appConfig = file_get_contents(config_path('app.php')), $providerClass)) {
             file_put_contents(config_path('app.php'), str_replace(
-                'App\\Providers\\'.$after.'::class,',
-                'App\\Providers\\'.$after.'::class,'.PHP_EOL."        $providerClass,",
+                'App\\Providers\\' . $after . '::class,',
+                'App\\Providers\\' . $after . '::class,' . PHP_EOL . "        $providerClass,",
                 $appConfig
             ));
         }
@@ -241,9 +241,9 @@ class FilamentModuleCommand extends Command
     /**
      * Install the middleware to a group in the application Http Kernel.
      *
-     * @param  string  $after
-     * @param  string  $name
-     * @param  string  $group
+     * @param string $after
+     * @param string $name
+     * @param string $group
      * @return void
      */
     protected function installMiddlewareAfter($after, $name, $group = 'web')
@@ -253,10 +253,10 @@ class FilamentModuleCommand extends Command
         $middlewareGroups = Str::before(Str::after($httpKernel, '$middlewareGroups = ['), '];');
         $middlewareGroup = Str::before(Str::after($middlewareGroups, "'$group' => ["), '],');
 
-        if (! Str::contains($middlewareGroup, $name)) {
+        if (!Str::contains($middlewareGroup, $name)) {
             $modifiedMiddlewareGroup = str_replace(
-                $after.',',
-                $after.','.PHP_EOL.'            '.$name.',',
+                $after . ',',
+                $after . ',' . PHP_EOL . '            ' . $name . ',',
                 $middlewareGroup,
             );
 

--- a/src/Commands/FilamentModuleMakeRelationManagerCommand.php
+++ b/src/Commands/FilamentModuleMakeRelationManagerCommand.php
@@ -13,17 +13,23 @@ class FilamentModuleMakeRelationManagerCommand extends MakeRelationManagerComman
 
     protected $description = 'Creates a Filament relation manager class for a resource.';
 
-    protected $signature = 'module:make-filament-relation-manager {module?} {resource?} {relationship?} {recordTitleAttribute?} {--attach} {--associate} {--soft-deletes} {--view} {--F|force}';
+    protected $signature = 'module:make-filament-relation-manager {resource?} {relationship?} {recordTitleAttribute?} {context?} {module?}  {--attach} {--associate} {--soft-deletes} {--view} {--F|force}';
 
     protected ?Module $module;
 
     public function handle(): int
     {
-        $module = (string) Str::of($this->argument('module') ?? $this->askRequired('Module Name (e.g. `sales`)', 'module'));
+        $module = $this->argument('module') ?: app('modules')->getUsedNow();
+        if (!$module) {
+            $module = (string) Str::of($this->askRequired('Module Name (e.g. `Sales`)', 'module'));
+        }
         $this->module = app('modules')->findOrFail($this->getModuleName());
 
-        $resourcePath = module_path($module, 'Filament/Resources/');
-        $resourceNamespace = $this->getModuleNamespace().'\\Filament\\Resources';
+        $contextInput = $this->argument('context') ?? $this->askRequired("Context Name",'context','Filament');
+        $context = Str::of($contextInput)->studly()->toString();
+
+        $resourcePath = module_path($module, "$context/Resources/");
+        $resourceNamespace = $this->getModuleNamespace()."\\$context\\Resources";
 
         $resource = (string) Str::of($this->argument('resource') ?? $this->askRequired('Resource (e.g. `DepartmentResource`)', 'resource'))
             ->studly()

--- a/src/Commands/FilamentModuleMakeResourceCommand.php
+++ b/src/Commands/FilamentModuleMakeResourceCommand.php
@@ -14,17 +14,21 @@ class FilamentModuleMakeResourceCommand extends MakeResourceCommand
 
     protected $description = 'Creates a Filament resource class and default page classes.';
 
-    protected $signature = 'module:make-filament-resource {module?} {name?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--F|force}';
+    protected $signature = 'module:make-filament-resource {name?} {context?} {module?} {--soft-deletes} {--view} {--G|generate} {--S|simple} {--F|force}';
 
     protected ?Module $module;
 
     public function handle(): int
     {
-        $module = (string) Str::of($this->argument('module') ?? $this->askRequired('Module Name (e.g. `sales`)', 'module'));
+        $context = Str::of($this->argument('context') ?? 'Filament')->studly()->toString();
+        $module = $this->argument('module') ?: app('modules')->getUsedNow();
+        if (!$module) {
+            $module = (string) Str::of($this->askRequired('Module Name (e.g. `Sales`)', 'module'));
+        }
         $this->module = app('modules')->findOrFail($this->getModuleName());
 
-        $path = module_path($module, 'Filament/Resources/');
-        $namespace = $this->getModuleNamespace().'\\Filament\\Resources';
+        $path = module_path($module, "$context/Resources/");
+        $namespace = $this->getModuleNamespace()."\\$context\\Resources";
 
         $model = Str::of($this->argument('name') ?? $this->askRequired('Model (e.g. `BlogPost`)', 'name'))
             ->studly()
@@ -173,6 +177,7 @@ class FilamentModuleMakeResourceCommand extends MakeResourceCommand
                 'namespace' => "{$namespace}\\{$resourceClass}\\Pages",
                 'resource' => "{$namespace}\\{$resourceClass}",
                 'resourceClass' => $resourceClass,
+                'resourceNamespace' => $resourceNamespace,
                 'resourcePageClass' => $manageResourcePageClass,
             ]);
         } else {
@@ -245,6 +250,5 @@ class FilamentModuleMakeResourceCommand extends MakeResourceCommand
         $filesystem->ensureDirectoryExists(
             Str::of($path)->rtrim('/')->toString(),
         );
-
     }
 }

--- a/src/FilamentModules.php
+++ b/src/FilamentModules.php
@@ -4,6 +4,7 @@ namespace Savannabits\FilamentModules;
 
 use Filament\Facades\Filament;
 use Filament\FilamentManager;
+use Filament\Navigation\NavigationItem;
 use Illuminate\Support\Traits\ForwardsCalls;
 
 class FilamentModules
@@ -106,4 +107,29 @@ class FilamentModules
 
         return $response;
     }
+
+    public static function registerFilamentNavigationItem($module, $context): void
+    {
+        $panel = \Str::of($context)->after('-')->replace('filament','default')->slug()->replace('-', ' ')->title()->title();
+        Filament::registerNavigationItems([
+            NavigationItem::make($context)->label("$panel Panel")->url(route($context.'.pages.dashboard'))->icon('heroicon-o-bookmark')->group("$module Module")
+        ]);
+    }
+    public static function renderContextNavigation($module, $context): void
+    {
+        Filament::registerRenderHook('sidebar.start',fn():string => \Blade::render('<div class="p-2 px-6 bg-primary-100 font-black w-full">'."$module Module</div>"));
+        Filament::registerRenderHook('sidebar.end',fn():string => \Blade::render('<a class="p-2 px-6 bg-primary-100 font-black w-full inline-flex space-x-2" href="'.route('filament.pages.dashboard').'"><x-heroicon-o-arrow-left class="w-5"/> Main Panel</a>'));
+    }
+    public function prepareDefaultNavigation($module, $context): void
+    {
+        Filament::serving(function () use($module, $context) {
+            Filament::forContext('filament', function () use($module, $context) {
+                app(FilamentModules::class)::registerFilamentNavigationItem($module,$context);
+            });
+            Filament::forContext($context, function () use ($module, $context) {
+                app(FilamentModules::class)::renderContextNavigation($module, $context);
+            });
+        });
+    }
+
 }

--- a/stubs/ContextServiceProvider.stub
+++ b/stubs/ContextServiceProvider.stub
@@ -5,6 +5,7 @@ namespace {{ namespace }};
 use Filament\Facades\Filament;
 use Filament\Navigation\NavigationItem;
 use Savannabits\FilamentModules\ContextServiceProvider;
+use Savannabits\FilamentModules\FilamentModules;
 
 class {{ class }} extends ContextServiceProvider
 {
@@ -29,15 +30,6 @@ class {{ class }} extends ContextServiceProvider
     public function boot()
     {
         parent::boot();
-        Filament::serving(function () {
-            Filament::forContext('filament', function (){
-                Filament::registerNavigationItems([
-                    NavigationItem::make(static::$module)->label(static::$module.' Module')->url(route(static::$name.'.pages.dashboard'))->icon('heroicon-o-bookmark')->group('Modules')
-                ]);
-            });
-            Filament::forContext(static::$name, function (){
-                Filament::registerRenderHook('sidebar.start',fn():string => \Blade::render('<div class="p-2 px-6 bg-primary-100 font-black w-full">'.static::$module.' Module</div>'));
-            });
-        });
+        app(FilamentModules::class)->prepareDefaultNavigation(static::$module, static::$name);
     }
 }

--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -17,6 +17,7 @@ $moduleName = '{{ module }}';
 $moduleNs = '{{ moduleNamespace }}';
 $contextNs = '{{ namespace }}';
 $contextPath = '{{ path }}';
+$path = Str::of($contextPath)->slug()->replace('filament','admin-panel');
 return [
 
     /*
@@ -29,7 +30,7 @@ return [
     |
     */
 
-    'path' => env('FILAMENT_PATH', 'admin'),
+    'path' => $path,
 
     /*
     |--------------------------------------------------------------------------
@@ -56,9 +57,7 @@ return [
     'pages' => [
         'namespace' => $contextNs.'\\Pages',
         'path' => module_path($moduleName, "$contextPath/Pages"),
-        'register' => [
-            Pages\Dashboard::class,
-        ],
+        'register' => [],
     ],
 
     /*


### PR DESCRIPTION
- Added ability to generate multiple contexts by specifying the context name
- Use the currently used module when generating a resource or page in case it is not specified.
- By default generate the Dashboard page when generating a context
- Modified the signatures for Resource, Page and RelationManager generation commands. run the commands with --help for details
- Re-factored the registration of Sidebar Nav items to factor multiple contexts under each module.