### PR TITLE
Bug Fixes: Enforce Permissions check only if filament-shield is installed:

### DIFF
--- a/src/FilamentModules.php
+++ b/src/FilamentModules.php
@@ -114,7 +114,8 @@ class FilamentModules
     public static function getModuleContexts(string $module): Collection
     {
         $prefix = Str::of($module)->lower()->append('-')->toString();
-        return collect(Filament::getContexts())->keys()->filter(fn($item) => Str::of($item)->contains("$prefix"));
+
+        return collect(Filament::getContexts())->keys()->filter(fn ($item) => Str::of($item)->contains("$prefix"));
     }
 
     public static function registerFilamentNavigationItem($module, $context): void
@@ -133,7 +134,7 @@ class FilamentModules
 
     public static function hasAuthorizedAccess(string $context)
     {
-        if (!app()->has('filament-shield')) {
+        if (! app()->has('filament-shield')) {
             return true;
         }
         $module = Str::of($context)->before('-')->lower();

--- a/src/FilamentModules.php
+++ b/src/FilamentModules.php
@@ -135,6 +135,7 @@ class FilamentModules
     public static function hasAuthorizedAccess(string $context)
     {
         $module = Str::of($context)->before('-')->lower();
+
         return Filament::auth()->check() && Filament::auth()->user()->can('module_'.$module);
     }
 

--- a/src/FilamentModules.php
+++ b/src/FilamentModules.php
@@ -114,8 +114,7 @@ class FilamentModules
     public static function getModuleContexts(string $module): Collection
     {
         $prefix = Str::of($module)->lower()->append('-')->toString();
-
-        return collect(Filament::getContexts())->keys()->filter(fn ($item) => Str::of($item)->contains("$prefix"));
+        return collect(Filament::getContexts())->keys()->filter(fn($item) => Str::of($item)->contains("$prefix"));
     }
 
     public static function registerFilamentNavigationItem($module, $context): void
@@ -123,7 +122,7 @@ class FilamentModules
         $panel = Str::of($context)->after('-')->replace('filament', 'default')->slug()->replace('-', ' ')->title()->title();
         $moduleContexts = static::getModuleContexts($module);
         $module_lower = \Module::findOrFail($module)->getLowerName();
-        $can = Filament::auth()->check() && Filament::auth()->user()->can("module_{$module_lower}");
+        $can = static::hasAuthorizedAccess($context);
         $navItem = NavigationItem::make($context)->visible($can)->url(route($context.'.pages.dashboard'))->icon('heroicon-o-bookmark');
         if ($can) {
             Filament::registerNavigationItems([
@@ -134,6 +133,9 @@ class FilamentModules
 
     public static function hasAuthorizedAccess(string $context)
     {
+        if (!app()->has('filament-shield')) {
+            return true;
+        }
         $module = Str::of($context)->before('-')->lower();
 
         return Filament::auth()->check() && Filament::auth()->user()->can('module_'.$module);

--- a/src/FilamentModulesServiceProvider.php
+++ b/src/FilamentModulesServiceProvider.php
@@ -44,17 +44,20 @@ class FilamentModulesServiceProvider extends PluginServiceProvider
 
     public function configurePackage(Package $package): void
     {
+        $commands = [
+            FilamentModuleCommand::class,
+            FilamentGuardCommand::class,
+            FilamentModuleMakePageCommand::class,
+            FilamentModuleMakeRelationManagerCommand::class,
+            FilamentModuleMakeResourceCommand::class,
+            FilamentModuleMakeWidgetCommand::class,
+        ];
+        if ($this->app->has('filament-shield')) {
+            $commands[] = ShieldGenerateCommand::class;
+        }
         $package->name(static::$name)
             ->hasConfigFile()
-            ->hasCommands([
-                FilamentModuleCommand::class,
-                FilamentGuardCommand::class,
-                FilamentModuleMakePageCommand::class,
-                FilamentModuleMakeRelationManagerCommand::class,
-                FilamentModuleMakeResourceCommand::class,
-                FilamentModuleMakeWidgetCommand::class,
-                ShieldGenerateCommand::class,
-            ]);
+            ->hasCommands($commands);
     }
 
     public function packageRegistered(): void


### PR DESCRIPTION
Bug Fixes: Enforce Permissions check only if filament-shield is installed:
    - Register the Generate command only if filament shield is installed
    - If filament shield is installed, return true to all access queries to the modular contexts