### PR TITLE
Filament Shield Extension Enhancement:

### DIFF
--- a/src/Extensions/FilamentShield.php
+++ b/src/Extensions/FilamentShield.php
@@ -81,7 +81,7 @@ class FilamentShield extends \BezhanSalleh\FilamentShield\FilamentShield
         return invade(new $object())->getNavigationLabel();
     }
 
-    protected function getDefaultPermissionIdentifier(string $resource): string
+    public function getDefaultPermissionIdentifier(string $resource): string
     {
         return Str::of($resource)
             ->replace('Resources\\', '')


### PR DESCRIPTION
 Make `getDefaultPermissionIdentifier` method public to allow re-use from other classes