### PR TITLE
Bug Fix: navigation label translation key during filament cluster generation

### DIFF
--- a/src/Commands/stubs/filament-cluster.stub
+++ b/src/Commands/stubs/filament-cluster.stub
@@ -19,7 +19,7 @@ class {{ class }} extends Cluster
 
     public static function getNavigationLabel(): string
     {
-        return '__({{ navigationLabel }})';
+        return __('{{ navigationLabel }}');
     }
 
     public static function getNavigationIcon(): ?string


### PR DESCRIPTION
- navigation key translation was wrong. Fixed.