### PR TITLE
Bug Fix: Wrong Directory Separators causing errors when registering Module Plugins

### DIFF
--- a/src/Commands/ModuleMakeFilamentPageCommand.php
+++ b/src/Commands/ModuleMakeFilamentPageCommand.php
@@ -239,7 +239,7 @@ class ModuleMakeFilamentPageCommand extends MakePageCommand
             (string) str($view)
                 ->replace($module->getLowerName() . '::', '')
                 ->replace('.', DIRECTORY_SEPARATOR)
-                ->prepend('views'.DIRECTORY_SEPARATOR)
+                ->prepend('views' . DIRECTORY_SEPARATOR)
                 ->append('.blade.php'),
         );
 

--- a/src/Commands/ModuleMakeFilamentPageCommand.php
+++ b/src/Commands/ModuleMakeFilamentPageCommand.php
@@ -37,7 +37,7 @@ class ModuleMakeFilamentPageCommand extends MakePageCommand
             ->trim('/')
             ->trim('\\')
             ->trim(' ')
-            ->replace('/', '\\');
+            ->replace(DIRECTORY_SEPARATOR, '\\');
         $pageClass = (string) str($page)->afterLast('\\');
         $pageNamespace = str($page)->contains('\\') ?
             (string) str($page)->beforeLast('\\') :
@@ -86,7 +86,7 @@ class ModuleMakeFilamentPageCommand extends MakePageCommand
                 ->trim('/')
                 ->trim('\\')
                 ->trim(' ')
-                ->replace('/', '\\');
+                ->replace(DIRECTORY_SEPARATOR, '\\');
 
             if (! str($resource)->endsWith('Resource')) {
                 $resource .= 'Resource';
@@ -229,17 +229,17 @@ class ModuleMakeFilamentPageCommand extends MakePageCommand
             ->implode('.'))->prepend($module->getLowerName() . '::');
 
         $path = (string) str($page)
-            ->prepend('/')
+            ->prepend(DIRECTORY_SEPARATOR)
             ->prepend(empty($resource) ? $path : $resourcePath . "\\{$resource}\\Pages\\")
-            ->replace('\\', '/')
-            ->replace('//', '/')
+            ->replace('\\', DIRECTORY_SEPARATOR)
+            ->replace('//', DIRECTORY_SEPARATOR)
             ->append('.php');
 
         $viewPath = $module->resourcesPath(
             (string) str($view)
                 ->replace($module->getLowerName() . '::', '')
-                ->replace('.', '/')
-                ->prepend('views/')
+                ->replace('.', DIRECTORY_SEPARATOR)
+                ->prepend('views'.DIRECTORY_SEPARATOR)
                 ->append('.blade.php'),
         );
 

--- a/src/Commands/ModuleMakeFilamentThemeCommand.php
+++ b/src/Commands/ModuleMakeFilamentThemeCommand.php
@@ -40,7 +40,7 @@ class ModuleMakeFilamentThemeCommand extends MakeThemeCommand
             'yarn' => 'yarn add',
             default => "{$pm} install",
         };
-        $cdCommand = 'cd '.$module->getPath();
+        $cdCommand = 'cd ' . $module->getPath();
 
         exec("$cdCommand && {$installCommand} tailwindcss @tailwindcss/forms @tailwindcss/typography postcss postcss-nesting autoprefixer --save-dev");
 
@@ -66,9 +66,9 @@ class ModuleMakeFilamentThemeCommand extends MakeThemeCommand
             'viewPathPrefix' => $viewPathPrefix,
         ]);
 
-        $this->components->info('Filament theme [resources/css/filament/theme.css] and [resources/css/filament/tailwind.config.js] created successfully in '.$module->getStudlyName().' module.');
+        $this->components->info('Filament theme [resources/css/filament/theme.css] and [resources/css/filament/tailwind.config.js] created successfully in ' . $module->getStudlyName() . ' module.');
 
-        $buildDirectory = 'build-'.$module->getLowerName();
+        $buildDirectory = 'build-' . $module->getLowerName();
         $moduleStudlyName = $module->getStudlyName();
 
         if (empty(glob($module->getExtraPath('vite.config.*s')))) {
@@ -76,7 +76,7 @@ class ModuleMakeFilamentThemeCommand extends MakeThemeCommand
             $this->components->bulletList([
                 "It looks like you don't have Vite installed in your module. Please use your asset bundling system of choice to compile `resources/css/filament/theme.css` into `public/$buildDirectory/css/filament/theme.css`.",
                 "If you're not currently using a bundler, we recommend using Vite. Alternatively, you can use the Tailwind CLI with the following command inside the $moduleStudlyName module:",
-                'npx tailwindcss --input ./resources/css/filament/theme.css --output ./public/'.$buildDirectory.'/css/filament/theme.css --config ./resources/css/filament/tailwind.config.js --minify',
+                'npx tailwindcss --input ./resources/css/filament/theme.css --output ./public/' . $buildDirectory . '/css/filament/theme.css --config ./resources/css/filament/tailwind.config.js --minify',
                 "Make sure to register the theme in the {$moduleStudlyName} module plugin under the afterRegister() function using `->theme(asset('css/filament/theme.css'))`",
             ]);
 
@@ -103,7 +103,7 @@ class ModuleMakeFilamentThemeCommand extends MakeThemeCommand
 
     protected function getDefaultStubPath(): string
     {
-        return __DIR__.'/stubs';
+        return __DIR__ . '/stubs';
     }
 
     private function getModule(): Module

--- a/src/Concerns/ModuleFilamentPlugin.php
+++ b/src/Concerns/ModuleFilamentPlugin.php
@@ -19,15 +19,15 @@ trait ModuleFilamentPlugin
         $module = $this->getModule();
         $useClusters = config('filament-modules.clusters.enabled', false);
         $panel->discoverPages(
-            in: $module->appPath('Filament'.DIRECTORY_SEPARATOR.'Pages'),
+            in: $module->appPath('Filament' . DIRECTORY_SEPARATOR . 'Pages'),
             for: $module->appNamespace('\\Filament\\Pages')
         );
         $panel->discoverResources(
-            in: $module->appPath('Filament'.DIRECTORY_SEPARATOR.'Resources'),
+            in: $module->appPath('Filament' . DIRECTORY_SEPARATOR . 'Resources'),
             for: $module->appNamespace('\\Filament\\Resources')
         );
         $panel->discoverWidgets(
-            in: $module->appPath('Filament'.DIRECTORY_SEPARATOR.'Widgets'),
+            in: $module->appPath('Filament' . DIRECTORY_SEPARATOR . 'Widgets'),
             for: $module->appNamespace('\\Filament\\Widgets')
         );
 
@@ -37,7 +37,7 @@ trait ModuleFilamentPlugin
         );
 
         if ($useClusters) {
-            $path = $module->appPath('Filament'.DIRECTORY_SEPARATOR.'Clusters');
+            $path = $module->appPath('Filament' . DIRECTORY_SEPARATOR . 'Clusters');
             $namespace = $module->appNamespace('\\Filament\\Clusters');
             $panel->discoverClusters(
                 in: $path,

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -23,6 +23,8 @@ class Modules
 
         return str($relative)
             ->ltrim('/\\')
+            ->replace('/', DIRECTORY_SEPARATOR)
+            ->replace('\\', DIRECTORY_SEPARATOR)
             ->prepend(DIRECTORY_SEPARATOR)
             ->prepend(config('modules.namespace', 'Modules'))
             ->replace(DIRECTORY_SEPARATOR, '\\')

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -19,12 +19,10 @@ class Modules
     public function convertPathToNamespace(string $fullPath): string
     {
         $base = str(trim(config('modules.paths.modules', base_path('Modules')), '/\\'));
-        $relative = str($fullPath)->afterLast($base)->ltrim('/\\app');
+        $relative = str($fullPath)->afterLast($base)->replaceFirst(DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
 
         return str($relative)
             ->ltrim('/\\')
-            ->replace('/', DIRECTORY_SEPARATOR)
-            ->replace('\\', DIRECTORY_SEPARATOR)
             ->prepend(DIRECTORY_SEPARATOR)
             ->prepend(config('modules.namespace', 'Modules'))
             ->replace(DIRECTORY_SEPARATOR, '\\')

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -51,6 +51,6 @@ class Modules
     public function packagePath(string $path = ''): string
     {
         //return the base path of this package
-        return dirname(__DIR__ . '../') . ($path ? DIRECTORY_SEPARATOR . trim($path, DIRECTORY_SEPARATOR) : '');
+        return dirname(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR) . ($path ? DIRECTORY_SEPARATOR . trim($path, DIRECTORY_SEPARATOR) : '');
     }
 }

--- a/src/ModulesPlugin.php
+++ b/src/ModulesPlugin.php
@@ -47,7 +47,7 @@ class ModulesPlugin implements Plugin
         }
         // get a glob of all Filament plugins
         $basePath = str(config('modules.paths.modules', 'Modules'));
-        $pattern = $basePath . '/*/app/Filament/*Plugin.php';
+        $pattern = $basePath . DIRECTORY_SEPARATOR . '*' . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Filament' . DIRECTORY_SEPARATOR . '*Plugin.php';
         $pluginPaths = glob($pattern);
 
         return collect($pluginPaths)->map(fn ($path) => FilamentModules::convertPathToNamespace($path))->toArray();


### PR DESCRIPTION
- Fixed DIRECTORY SEPARATORS to be platform-aware.
- Fixes #92 