### PR TITLE
Fix: Support nwidart/laravel-modules v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ properly before proceeding.
 
 **Task: Configure your Laravel Modules first before continuing.**
 
+### Autoloading modules
+
+Don't forget to autoload modules by adding the merge-plugin to your composer.json according to the [laravel modules documentation](https://laravelmodules.com/docs/12/getting-started/installation-and-setup#autoloading):
+
+```json
+"extra": {
+    "laravel": {
+        "dont-discover": []
+    },
+    "merge-plugin": {
+        "include": [
+            "Modules/*/composer.json"
+        ]
+    }
+},
+```
+
 Next, Run the installation command and follow the prompts to publish the config file and set up the package:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^8.2",
     "filament/filament": "^4.0",
-    "nwidart/laravel-modules": "^12.0",
+    "nwidart/laravel-modules": "^11.0|^12.0",
     "spatie/laravel-package-tools": "^1.15.0"
   },
   "require-dev": {


### PR DESCRIPTION
- Added backward compatible support for nwidart/laravel-modules v11, hence laravel 11.
- Update documentation to emphasize registration of the merge-plugin to enable module autoloading
- Fixes #140