### PR TITLE
Bug Fix: rtrim was erroneously removing s in Models

### DIFF
--- a/src/Commands/ModuleMakeFilamentResourceCommand.php
+++ b/src/Commands/ModuleMakeFilamentResourceCommand.php
@@ -73,7 +73,7 @@ class ModuleMakeFilamentResourceCommand extends MakeResourceCommand
             }
 
             $modelClass = class_basename($modelName);
-            $modelNamespace = str(trim($modelName, '\\'))->rtrim("\\{$modelClass}")->toString();
+            $modelNamespace = str(trim($modelName, '\\'))->beforeLast("\\{$modelClass}")->toString();
 
             if (! $modelName) {
                 $this->error('No model namespace selected. Aborting resource creation.');


### PR DESCRIPTION
- Use beforeLast instead of rtrim when generating resources
- Fixes #127 