### PR TITLE
Update laravel-modules version requirement for nWidart/laravel-module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^8.3",
     "filament/filament": "^4.0|^5.0",
-    "nwidart/laravel-modules": "^11.0|^12.0",
+    "nwidart/laravel-modules": "^11.0|^12.0|^13.0",
     "spatie/laravel-package-tools": "^1.15.0"
   },
   "require-dev": {


### PR DESCRIPTION
This pull request updates the `composer.json` file to expand support for the `nwidart/laravel-modules` package. The change allows the project to be compatible with version 13.x of the package, in addition to the previously supported versions.

Dependency updates:

* Updated the `nwidart/laravel-modules` version constraint to include `^13.0`, enabling compatibility with the latest major version.