### PR TITLE
feat(v6): module runtime contracts and Milestone 1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,6 +24,16 @@ whether or not your feature is likely to be used by other users of the project.
 
 ## Procedure
 
+### Branching
+
+`main` and `5.x` are protected — **do not push to them directly**.
+
+1. Branch from the target you intend to merge into:
+   - v6 work: `git checkout main && git pull && git checkout -b feature/my-change`
+   - v5 fixes: `git checkout 5.x && git pull && git checkout -b fix/my-change`
+2. Open a pull request into `main` or `5.x` as appropriate.
+3. Wait for CI to pass before requesting review.
+
 Before filing an issue:
 
 - Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,25 +2,40 @@ name: PHPStan
 
 on:
   push:
+    branches: [ main, 5.x, 'feature/**' ]
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
+      - 'composer.json'
+      - 'composer.lock'
+  pull_request:
+    branches: [ main, 5.x ]
+    paths:
+      - '**.php'
+      - 'phpstan.neon.dist'
+      - 'composer.json'
+      - 'composer.lock'
 
 jobs:
   phpstan:
-    name: phpstan
+    name: PHPStan · PHP 8.3
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
+          tools: composer:v2
 
-      - name: Install composer dependencies
+      - name: Install dependencies
         uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--prefer-dist --no-scripts'
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,20 +6,40 @@ on:
   pull_request:
     branches: [ main, 5.x ]
 
-jobs:
-  test-l11:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.2, 8.3, 8.4 ]
-        laravel: [ 11.*, 12.* ]
-        testbench: [ 9.* ]
-        carbon: [ 3.* ]
-        stability: [ prefer-lowest, prefer-stable ]
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.3'
+            laravel: ^11.0
+            testbench: ^9.12
+            os: ubuntu-latest
+          - php: '8.4'
+            laravel: ^11.0
+            testbench: ^9.12
+            os: ubuntu-latest
+          - php: '8.3'
+            laravel: ^12.0
+            testbench: ^10.0
+            os: ubuntu-latest
+          - php: '8.4'
+            laravel: ^12.0
+            testbench: ^10.0
+            os: ubuntu-latest
+          - php: '8.3'
+            laravel: ^11.0
+            testbench: ^9.12
+            os: windows-latest
+
+    name: PHP ${{ matrix.php }} · Laravel ${{ matrix.laravel }} · ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -29,22 +49,22 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv, fileinfo
           coverage: none
-
-      - name: Setup problem matchers
-        run: |
-          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+          tools: composer:v2
 
       - name: Install dependencies
+        env:
+          COMPOSER_PROCESS_TIMEOUT: 0
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer require \
+            "laravel/framework:${{ matrix.laravel }}" \
+            "orchestra/testbench:${{ matrix.testbench }}" \
+            --dev \
+            --no-interaction \
+            --no-update
+          composer update --prefer-stable --prefer-dist --no-interaction --no-scripts
+          composer dump-autoload
 
-      - name: List Installed Dependencies
-        run: composer show -D
-
-      - name: Execute tests
+      - name: Run tests
         run: vendor/bin/pest --ci
-

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,27 +19,13 @@ jobs:
       matrix:
         include:
           - php: '8.3'
-            laravel: ^11.0
-            testbench: ^9.12
             os: ubuntu-latest
           - php: '8.4'
-            laravel: ^11.0
-            testbench: ^9.12
             os: ubuntu-latest
           - php: '8.3'
-            laravel: ^12.0
-            testbench: ^10.0
-            os: ubuntu-latest
-          - php: '8.4'
-            laravel: ^12.0
-            testbench: ^10.0
-            os: ubuntu-latest
-          - php: '8.3'
-            laravel: ^11.0
-            testbench: ^9.12
             os: windows-latest
 
-    name: PHP ${{ matrix.php }} · Laravel ${{ matrix.laravel }} · ${{ matrix.os }}
+    name: PHP ${{ matrix.php }} · Laravel 12 · ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -58,8 +44,8 @@ jobs:
           COMPOSER_PROCESS_TIMEOUT: 0
         run: |
           composer require \
-            "laravel/framework:${{ matrix.laravel }}" \
-            "orchestra/testbench:${{ matrix.testbench }}" \
+            "laravel/framework:^12.0" \
+            "orchestra/testbench:^10.0" \
             --dev \
             --no-interaction \
             --no-update

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,13 +19,42 @@ jobs:
       matrix:
         include:
           - php: '8.3'
+            laravel: ^12.0
+            testbench: ^10.0
+            pest: ^3.8
+            pest-laravel: ^3.1
+            pest-livewire: ^3.0
             os: ubuntu-latest
           - php: '8.4'
+            laravel: ^12.0
+            testbench: ^10.0
+            pest: ^3.8
+            pest-laravel: ^3.1
+            pest-livewire: ^3.0
             os: ubuntu-latest
           - php: '8.3'
+            laravel: ^13.0
+            testbench: ^11.0
+            pest: ^4.4
+            pest-laravel: ^4.1
+            pest-livewire: ^4.1
+            os: ubuntu-latest
+          - php: '8.4'
+            laravel: ^13.0
+            testbench: ^11.0
+            pest: ^4.4
+            pest-laravel: ^4.1
+            pest-livewire: ^4.1
+            os: ubuntu-latest
+          - php: '8.3'
+            laravel: ^12.0
+            testbench: ^10.0
+            pest: ^3.8
+            pest-laravel: ^3.1
+            pest-livewire: ^3.0
             os: windows-latest
 
-    name: PHP ${{ matrix.php }} · Laravel 12 · ${{ matrix.os }}
+    name: PHP ${{ matrix.php }} · Laravel ${{ matrix.laravel }} · ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -44,8 +73,11 @@ jobs:
           COMPOSER_PROCESS_TIMEOUT: 0
         run: |
           composer require \
-            "laravel/framework:^12.0" \
-            "orchestra/testbench:^10.0" \
+            "laravel/framework:${{ matrix.laravel }}" \
+            "orchestra/testbench:${{ matrix.testbench }}" \
+            "pestphp/pest:${{ matrix.pest }}" \
+            "pestphp/pest-plugin-laravel:${{ matrix.pest-laravel }}" \
+            "pestphp/pest-plugin-livewire:${{ matrix.pest-livewire }}" \
             --dev \
             --no-interaction \
             --no-update

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: run-tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 5.x, 'feature/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 5.x ]
 
 jobs:
   test-l11:

--- a/V6-ROADMAP.md
+++ b/V6-ROADMAP.md
@@ -16,6 +16,19 @@ v5 continues to wrap [nwidart/laravel-modules](https://github.com/nWidart/larave
 
 ---
 
+## Requirements (v6)
+
+| Dependency | Version |
+|------------|---------|
+| PHP | 8.3+ |
+| Laravel | 12.x+ |
+| Filament | 4.x or 5.x |
+| nwidart/laravel-modules | 12.x or 13.x |
+
+v5 remains on Laravel 11+ and Filament 4.x on the `5.x` branch. v6 drops Laravel 11 support.
+
+---
+
 ## Goals
 
 1. **Organize Filament code into modules** — resources, pages, widgets, clusters, and optional sub-panels per module.
@@ -318,4 +331,4 @@ ModuleRegistry::find('Blog')?->dependencies();
 
 ## v6 release tagline
 
-> **Filament Modules v6 — modular Filament with tenant-aware activation and safe dependency boundaries, driver-agnostic by design.**
+> **Filament Modules v6 — modular Filament for Laravel 12+ with tenant-aware activation and safe dependency boundaries, driver-agnostic by design.**

--- a/V6-ROADMAP.md
+++ b/V6-ROADMAP.md
@@ -6,11 +6,18 @@ This document defines the architecture and release plan for **coolsam/modules v6
 
 | Branch | Purpose |
 |--------|---------|
-| `5.x` | Maintenance line for v5 — bug fixes and compatibility patches only |
-| `main` | Protected default branch — merge via pull request only |
-| `feature/*` | v6 development (e.g. `feature/v6-module-runtime`) |
+| `main` | Default branch for v6 — **protected**, merge via pull request only |
+| `5.x` | Maintenance line for v5 — **protected**, merge via pull request only |
+| `feature/*` | All development work (v6 and v5 fixes) |
 
-All v6 work lands on feature branches and merges to `main` through pull requests. Do not push directly to `main`.
+**No direct pushes** to `main` or `5.x`. Every change goes through a feature branch and a pull request:
+
+| Target | Use for | Example branch |
+|--------|---------|----------------|
+| `main` | v6 features and breaking changes | `feature/v6-module-runtime` |
+| `5.x` | v5 bug fixes and compatibility patches | `fix/nwidart-facade-alias` |
+
+CI runs on pushes to `feature/**` and on pull requests into `main` or `5.x`.
 
 v5 continues to wrap [nwidart/laravel-modules](https://github.com/nWidart/laravel-modules) with disk-based enable/disable. v6 introduces a driver-agnostic module runtime with **tenant-scoped activation** and **dependency enforcement**, while keeping nwidart as the default discovery driver.
 

--- a/V6-ROADMAP.md
+++ b/V6-ROADMAP.md
@@ -28,7 +28,7 @@ v5 continues to wrap [nwidart/laravel-modules](https://github.com/nWidart/larave
 | Dependency | Version |
 |------------|---------|
 | PHP | 8.3+ |
-| Laravel | 12.x+ |
+| Laravel | 12.x and 13.x |
 | Filament | 4.x or 5.x |
 | nwidart/laravel-modules | 12.x or 13.x |
 
@@ -338,4 +338,4 @@ ModuleRegistry::find('Blog')?->dependencies();
 
 ## v6 release tagline
 
-> **Filament Modules v6 — modular Filament for Laravel 12+ with tenant-aware activation and safe dependency boundaries, driver-agnostic by design.**
+> **Filament Modules v6 — modular Filament for Laravel 12 and 13 with tenant-aware activation and safe dependency boundaries, driver-agnostic by design.**

--- a/V6-ROADMAP.md
+++ b/V6-ROADMAP.md
@@ -1,0 +1,321 @@
+# Filament Modules v6 Roadmap
+
+This document defines the architecture and release plan for **coolsam/modules v6**.
+
+## Branch strategy
+
+| Branch | Purpose |
+|--------|---------|
+| `5.x` | Maintenance line for v5 — bug fixes and compatibility patches only |
+| `main` | Protected default branch — merge via pull request only |
+| `feature/*` | v6 development (e.g. `feature/v6-module-runtime`) |
+
+All v6 work lands on feature branches and merges to `main` through pull requests. Do not push directly to `main`.
+
+v5 continues to wrap [nwidart/laravel-modules](https://github.com/nWidart/laravel-modules) with disk-based enable/disable. v6 introduces a driver-agnostic module runtime with **tenant-scoped activation** and **dependency enforcement**, while keeping nwidart as the default discovery driver.
+
+---
+
+## Goals
+
+1. **Organize Filament code into modules** — resources, pages, widgets, clusters, and optional sub-panels per module.
+2. **Organize modules in Filament panels** — single admin panel with plugins/clusters by default; sub-panels when isolation is required.
+3. **Per-tenant activation/deactivation** — enable or disable modules at runtime per tenant (SaaS feature flags).
+4. **Dependency constraints** — cannot enable a module without its dependencies active; cannot disable or uninstall while other active modules depend on it.
+5. **Driver-agnostic design** — nwidart is the first driver; a future modular system can replace it without rewriting the Filament layer.
+
+---
+
+## Core insight: discovery vs activation
+
+nwidart conflates two responsibilities:
+
+| Responsibility | Meaning | Owner in v6 |
+|----------------|---------|-------------|
+| **Discovery** | Module exists on disk, has paths, manifest, autoload | **Driver** (`NwidartDriver`) |
+| **Activation** | Module is enabled for *this request / this tenant* | **Package** (`ModuleActivator`) |
+
+Filament registration, route bootstrapping, and `canAccess()` checks use **activation**, not nwidart's `modules_statuses.json`. Module PHP classes remain autoloaded via Composer; activation gates what registers in the panel and what runs for the current tenant.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Contracts (stable public API)                              │
+│  ModuleDefinition · ModuleRegistry · ModuleActivator        │
+│  TenantContext · DependencyResolver                         │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+         ┌─────────────────┴─────────────────┐
+         ▼                                   ▼
+┌─────────────────┐               ┌─────────────────────┐
+│  Drivers        │               │  Activation stores  │
+│  NwidartDriver  │               │  Database (tenant)  │
+│  (future…)      │               │  File (fallback)    │
+└─────────────────┘               └─────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Filament bridge                                            │
+│  ModulesPlugin · ModuleFilamentPlugin · CanAccessTrait      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Contracts
+
+```php
+interface ModuleDefinition
+{
+    public function name(): string;
+    public function alias(): string;
+    public function path(): string;
+    /** @return list<string> */
+    public function dependencies(): array;
+    /** @return array<string, mixed> */
+    public function manifest(): array;
+}
+
+interface ModuleRegistry
+{
+    public function all(): Collection;
+    public function find(string $name): ?ModuleDefinition;
+    public function exists(string $name): bool;
+}
+
+interface TenantContext
+{
+    public function resolve(): string|int|null; // null = single-tenant / global
+}
+
+interface ModuleActivator
+{
+    public function isActive(ModuleDefinition|string $module, string|int|null $tenantId = null): bool;
+    public function active(string|int|null $tenantId = null): Collection;
+    public function activate(ModuleDefinition|string $module, string|int|null $tenantId = null): void;
+    public function deactivate(ModuleDefinition|string $module, string|int|null $tenantId = null): void;
+}
+
+interface DependencyResolver
+{
+    public function assertCanActivate(ModuleDefinition|string $module, string|int|null $tenantId = null): void;
+    public function assertCanDeactivate(ModuleDefinition|string $module, string|int|null $tenantId = null): void;
+    /** @return list<string> */
+    public function activationOrder(ModuleDefinition|string $module): array;
+    /** @return list<string> */
+    public function dependents(ModuleDefinition|string $module, string|int|null $tenantId = null): array;
+}
+```
+
+**Rule:** no code in this package calls `\Module::isEnabled()` or `\Module::allEnabled()` directly. Use `ModuleActivator` and `ModuleRegistry`.
+
+---
+
+## Per-tenant activation
+
+### Data model
+
+```sql
+-- tenant_module_activations
+tenant_id      uuid/bigint  not null
+module         varchar      not null   -- studly name, e.g. Blog
+activated_at   timestamp    not null
+activated_by   nullable
+version        nullable     -- manifest version at activation time
+primary key (tenant_id, module)
+```
+
+Optional: `tenant_module_activation_logs` for audit history.
+
+### Activation flow
+
+**Activate**
+
+1. Resolve module via `ModuleRegistry`.
+2. `DependencyResolver::assertCanActivate()` — all `requires` modules must exist and be active for the tenant.
+3. Run module lifecycle hook (`onActivate($tenant)`).
+4. Persist row in `tenant_module_activations`.
+5. Clear tenant module cache.
+
+**Deactivate**
+
+1. `DependencyResolver::assertCanDeactivate()` — block if any **active** module depends on this one.
+2. Run module lifecycle hook (`onDeactivate($tenant)`).
+3. Delete activation row.
+4. Clear cache.
+
+### Tenant context
+
+Stay package-agnostic — do not hard-code Stancl Tenancy or Spatie Multitenancy.
+
+```php
+// config/filament-modules.php
+'tenancy' => [
+    'enabled' => false,
+    'context' => null, // e.g. App\Support\FilamentTenantContext::class
+],
+```
+
+When `tenancy.enabled` is `false`, the activator uses global mode (`FileModuleActivator` wrapping `modules_statuses.json`).
+
+### Runtime behavior
+
+For a tenant where module `Blog` is inactive:
+
+- `ModuleFilamentPlugin::register()` returns early.
+- `ModulesPlugin` loads only tenant-active plugins.
+- `CanAccessTrait` denies access.
+- Module service providers may remain registered; gate Filament, routes, and permissions via the activator (lazy provider registration is a future optimization).
+
+---
+
+## Dependency enforcement
+
+### Manifest extension
+
+Extend `module.json` with optional keys (nwidart ignores unknown keys):
+
+```json
+{
+  "name": "Shop",
+  "alias": "shop",
+  "requires": ["Core", "Blog"],
+  "filament": {
+    "plugin": "ShopPlugin",
+    "panels": ["admin"],
+    "cluster": "Shop"
+  }
+}
+```
+
+### Rules
+
+| Action | Rule |
+|--------|------|
+| **Enable** | All `requires` modules exist in the registry and are active for the tenant |
+| **Disable** | No other **active** module lists this one in `requires` |
+| **Uninstall** | Same as disable, plus dry-run report for migrations and data |
+
+### New Artisan commands
+
+```bash
+php artisan module:activate Shop --tenant=acme
+php artisan module:deactivate Shop --tenant=acme
+php artisan module:activation-status --tenant=acme
+php artisan module:filament:uninstall Shop --dry-run
+```
+
+nwidart's `module:enable` / `module:disable` become deprecated aliases delegating to the activator in global mode.
+
+---
+
+## Filament panel organization
+
+| Use case | Recommended mode |
+|----------|------------------|
+| SaaS admin, tenant feature flags | `plugins` + clusters (default) |
+| Separate mini-apps per domain | `panels` or `both` |
+| Simple single-tenant app | `plugins`, global file activator |
+
+### Default: one panel + plugin per module + optional cluster
+
+```
+/admin
+├── Core (cluster)
+├── Blog (cluster)     ← hidden when inactive for tenant
+└── Shop (cluster)
+```
+
+### Optional: module sub-panels
+
+Use when a module needs different middleware, branding, or auth. Navigation links in the main panel appear only when the module is active for the tenant.
+
+Tenant activation applies to both plugins and panel navigation links in `ModulesPlugin`.
+
+---
+
+## Driver strategy
+
+### v6.0 — Nwidart driver (default)
+
+`NwidartModuleRegistry` implements `ModuleRegistry`:
+
+- Discovers modules via nwidart.
+- Reads `module.json` for `requires` and `filament` config.
+- Does not treat `modules_statuses.json` as source of truth when the database activator is enabled.
+
+### Future driver
+
+A replacement modular system only implements `ModuleRegistry` (and optionally path helpers). Filament commands, stubs, tenant activation, and dependency resolution remain unchanged.
+
+---
+
+## Release milestones
+
+### Milestone 1 — Internal refactor (no user-visible breakage)
+
+- [x] Introduce contracts and `NwidartModuleRegistry`.
+- [x] Replace direct `\Module::` / `isEnabled()` usage in this package.
+- [x] Ship `FileModuleActivator` for backward-compatible global mode.
+- [x] Bind contracts in `ModulesServiceProvider`.
+
+### Milestone 2 — Tenant activation
+
+- [ ] Migration and `DatabaseModuleActivator`.
+- [ ] `TenantContext` contract and config.
+- [ ] Cache layer: `tenant:{id}:active_modules`.
+- [ ] Update `ModuleFilamentPlugin`, `ModulesPlugin`, `CanAccessTrait`, `ModulesServiceProvider`.
+
+### Milestone 3 — Dependencies
+
+- [ ] `ModuleDependencyResolver` with graph cache.
+- [ ] Manifest validation on activate.
+- [ ] New Artisan commands and typed exceptions.
+
+### Milestone 4 — Lifecycle and uninstall safety
+
+- [ ] Optional `ModuleLifecycle` contract on module service providers.
+- [ ] `module:filament:uninstall --dry-run`.
+- [ ] Filament admin page for per-tenant module management (may ship as v6.1).
+
+### Milestone 5 — Documentation and migration
+
+- [ ] v5 → v6 upgrade guide.
+- [ ] Single-tenant: file activator, no DB required.
+- [ ] Multi-tenant: publish migration, bind `TenantContext`.
+- [ ] Update README and CHANGELOG.
+
+---
+
+## Public API (target)
+
+```php
+use Coolsam\Modules\Facades\ModuleActivator;
+use Coolsam\Modules\Facades\ModuleRegistry;
+
+// Single-tenant
+ModuleActivator::activate('Blog');
+ModuleActivator::isActive('Blog');
+
+// Multi-tenant
+ModuleActivator::activate('Blog', tenantId: $tenant->id);
+ModuleActivator::isActive('Blog', tenantId: $tenant->id);
+
+ModuleRegistry::find('Blog')?->dependencies();
+```
+
+---
+
+## Out of scope for v6
+
+- Replacing nwidart in the same release as tenant activation.
+- Tenant-scoped Composer autoloading.
+- Coupling to a specific tenancy package.
+- Silent dependency resolution (always show activation order in CLI/UI).
+
+---
+
+## v6 release tagline
+
+> **Filament Modules v6 — modular Filament with tenant-aware activation and safe dependency boundaries, driver-agnostic by design.**

--- a/V6-ROADMAP.md
+++ b/V6-ROADMAP.md
@@ -31,6 +31,7 @@ v5 continues to wrap [nwidart/laravel-modules](https://github.com/nWidart/larave
 | Laravel | 12.x and 13.x |
 | Filament | 4.x or 5.x |
 | nwidart/laravel-modules | 12.x or 13.x |
+| orchestra/testbench (dev) | ^10 (L12) / ^11 (L13) |
 
 v5 remains on Laravel 11+ and Filament 4.x on the `5.x` branch. v6 drops Laravel 11 support.
 

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,12 @@
   },
   "require-dev": {
     "barryvdh/laravel-ide-helper": "^3.5",
-    "laravel/framework": "^13.0",
     "laravel/pint": "^1.0",
     "nunomaduro/larastan": "^3.1.0",
-    "orchestra/testbench": "^11.0",
-    "pestphp/pest": "^4.4",
-    "pestphp/pest-plugin-laravel": "^4.1",
-    "pestphp/pest-plugin-livewire": "^4.1",
+    "orchestra/testbench": "^10.0|^11.0",
+    "pestphp/pest": "^3.8|^4.4",
+    "pestphp/pest-plugin-laravel": "^3.1|^4.1",
+    "pestphp/pest-plugin-livewire": "^3.0|^4.1",
     "phpstan/extension-installer": "^1.4.3",
     "spatie/laravel-ray": "^1.39"
   },

--- a/composer.json
+++ b/composer.json
@@ -23,17 +23,19 @@
   "require": {
     "php": "^8.3",
     "filament/filament": "^4.0|^5.0",
-    "illuminate/contracts": "^12.0",
+    "illuminate/contracts": "^12.0|^13.0",
     "nwidart/laravel-modules": "^12.0|^13.0",
     "spatie/laravel-package-tools": "^1.15.0"
   },
   "require-dev": {
     "barryvdh/laravel-ide-helper": "^3.5",
+    "laravel/framework": "^13.0",
     "laravel/pint": "^1.0",
     "nunomaduro/larastan": "^3.1.0",
-    "orchestra/testbench": "^10.0",
-    "pestphp/pest-plugin-laravel": "^3.1",
-    "pestphp/pest-plugin-livewire": "^3.0",
+    "orchestra/testbench": "^11.0",
+    "pestphp/pest": "^4.4",
+    "pestphp/pest-plugin-laravel": "^4.1",
+    "pestphp/pest-plugin-livewire": "^4.1",
     "phpstan/extension-installer": "^1.4.3",
     "spatie/laravel-ray": "^1.39"
   },

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,9 @@
         "Coolsam\\Modules\\ModulesServiceProvider"
       ],
       "aliases": {
-        "FilamentModules": "FilamentModules"
+        "FilamentModules": "FilamentModules",
+        "ModuleActivator": "Coolsam\\Modules\\Facades\\ModuleActivator",
+        "ModuleRegistry": "Coolsam\\Modules\\Facades\\ModuleRegistry"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,15 @@
   "require": {
     "php": "^8.3",
     "filament/filament": "^4.0|^5.0",
-    "nwidart/laravel-modules": "^11.0|^12.0|^13.0",
+    "illuminate/contracts": "^12.0",
+    "nwidart/laravel-modules": "^12.0|^13.0",
     "spatie/laravel-package-tools": "^1.15.0"
   },
   "require-dev": {
     "barryvdh/laravel-ide-helper": "^3.5",
     "laravel/pint": "^1.0",
     "nunomaduro/larastan": "^3.1.0",
-    "orchestra/testbench": "^9.12",
+    "orchestra/testbench": "^10.0",
     "pestphp/pest-plugin-laravel": "^3.1",
     "pestphp/pest-plugin-livewire": "^3.0",
     "phpstan/extension-installer": "^1.4.3",

--- a/config/filament-modules.php
+++ b/config/filament-modules.php
@@ -2,6 +2,14 @@
 
 // config for Coolsam/Modules
 return [
+    'driver' => 'nwidart', // module discovery driver (nwidart, future drivers)
+    'activation' => [
+        'driver' => 'file', // file (modules_statuses.json) or database (per-tenant, v6 Milestone 2)
+    ],
+    'tenancy' => [
+        'enabled' => false,
+        'context' => null, // e.g. App\Support\FilamentTenantContext::class
+    ],
     'mode' => \Coolsam\Modules\Enums\ConfigMode::BOTH->value, // 'plugins' or 'panels', determines how the Filament Modules are registered
     'auto-register-plugins' => true, // whether to auto-register plugins from various modules in the Panel. Only relevant if 'mode' is set to 'plugins'.
     'clusters' => [

--- a/src/Activation/FileModuleActivator.php
+++ b/src/Activation/FileModuleActivator.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Coolsam\Modules\Activation;
+
+use Coolsam\Modules\Contracts\DependencyResolver;
+use Coolsam\Modules\Contracts\ModuleActivator;
+use Coolsam\Modules\Contracts\ModuleDefinition;
+use Coolsam\Modules\Contracts\ModuleRegistry;
+use Coolsam\Modules\Contracts\TenantContext;
+use Illuminate\Support\Collection;
+use Nwidart\Modules\Facades\Module;
+use RuntimeException;
+
+class FileModuleActivator implements ModuleActivator
+{
+    public function __construct(
+        protected ModuleRegistry $registry,
+        protected DependencyResolver $dependencyResolver,
+        protected TenantContext $tenantContext,
+    ) {}
+
+    public function isActive(ModuleDefinition | string $module, string | int | null $tenantId = null): bool
+    {
+        $tenantId = $tenantId ?? $this->tenantContext->resolve();
+
+        if ($tenantId !== null && config('filament-modules.tenancy.enabled', false)) {
+            throw new RuntimeException(
+                'Per-tenant activation requires the database activator. See V6-ROADMAP.md Milestone 2.'
+            );
+        }
+
+        $name = $this->resolveName($module);
+
+        return Module::find($name)?->isEnabled() ?? false;
+    }
+
+    public function active(string | int | null $tenantId = null): Collection
+    {
+        return $this->registry->all()
+            ->filter(fn (ModuleDefinition $module) => $this->isActive($module, $tenantId))
+            ->values();
+    }
+
+    public function activate(ModuleDefinition | string $module, string | int | null $tenantId = null): void
+    {
+        $tenantId = $tenantId ?? $this->tenantContext->resolve();
+        $definition = $this->resolveDefinition($module);
+
+        if ($tenantId !== null && config('filament-modules.tenancy.enabled', false)) {
+            throw new RuntimeException(
+                'Per-tenant activation requires the database activator. See V6-ROADMAP.md Milestone 2.'
+            );
+        }
+
+        $this->dependencyResolver->assertCanActivate($definition, $tenantId);
+
+        foreach ($this->dependencyResolver->activationOrder($definition) as $moduleName) {
+            Module::find($moduleName)?->enable();
+        }
+    }
+
+    public function deactivate(ModuleDefinition | string $module, string | int | null $tenantId = null): void
+    {
+        $tenantId = $tenantId ?? $this->tenantContext->resolve();
+        $definition = $this->resolveDefinition($module);
+
+        if ($tenantId !== null && config('filament-modules.tenancy.enabled', false)) {
+            throw new RuntimeException(
+                'Per-tenant activation requires the database activator. See V6-ROADMAP.md Milestone 2.'
+            );
+        }
+
+        $this->dependencyResolver->assertCanDeactivate($definition, $tenantId);
+
+        Module::find($definition->name())?->disable();
+    }
+
+    protected function resolveDefinition(ModuleDefinition | string $module): ModuleDefinition
+    {
+        if ($module instanceof ModuleDefinition) {
+            return $module;
+        }
+
+        $definition = $this->registry->find($module);
+
+        if (! $definition) {
+            throw new RuntimeException("Module [{$module}] was not found.");
+        }
+
+        return $definition;
+    }
+
+    protected function resolveName(ModuleDefinition | string $module): string
+    {
+        return $module instanceof ModuleDefinition
+            ? $module->name()
+            : $module;
+    }
+}

--- a/src/Commands/FileGenerators/ModulePanelProviderClassGenerator.php
+++ b/src/Commands/FileGenerators/ModulePanelProviderClassGenerator.php
@@ -36,7 +36,7 @@ class ModulePanelProviderClassGenerator extends ClassGenerator
         protected string $navigationLabel,
         protected bool $isDefault = false,
     ) {
-        $this->module = \Module::find($this->moduleName);
+        $this->module = \Nwidart\Modules\Facades\Module::find($this->moduleName);
         if (! $this->module) {
             throw new \InvalidArgumentException("Module '{$this->moduleName}' not found.");
         }

--- a/src/Commands/ModuleMakeFilamentClusterCommand.php
+++ b/src/Commands/ModuleMakeFilamentClusterCommand.php
@@ -39,7 +39,7 @@ class ModuleMakeFilamentClusterCommand extends MakeClusterCommand
     public function ensureModuleArgument(): void
     {
         if (! $this->argument('module')) {
-            $module = select('Please select the module to create the cluster in:', \Module::allEnabled());
+            $module = select('Please select the module to create the cluster in:', \Coolsam\Modules\Facades\ModuleRegistry::all()->map(fn ($m) => $m->name())->all());
             if (! $module) {
                 $this->error('No module selected. Aborting cluster creation.');
                 exit(1);

--- a/src/Commands/ModuleMakeFilamentPageCommand.php
+++ b/src/Commands/ModuleMakeFilamentPageCommand.php
@@ -52,7 +52,7 @@ class ModuleMakeFilamentPageCommand extends MakePageCommand
     public function ensureModuleArgument(): void
     {
         if (! $this->argument('module')) {
-            $module = select('Please select the module to create the page in:', \Module::allEnabled());
+            $module = select('Please select the module to create the page in:', \Coolsam\Modules\Facades\ModuleRegistry::all()->map(fn ($m) => $m->name())->all());
             if (! $module) {
                 $this->error('No module selected. Aborting page creation.');
                 exit(1);

--- a/src/Commands/ModuleMakeFilamentPanelCommand.php
+++ b/src/Commands/ModuleMakeFilamentPanelCommand.php
@@ -110,7 +110,7 @@ class ModuleMakeFilamentPanelCommand extends MakePanelCommand
     protected function ensureModuleArgument(): void
     {
         if (! $this->argument('module')) {
-            $module = select('Please select the module to create the panel in:', \Module::allEnabled());
+            $module = select('Please select the module to create the panel in:', \Coolsam\Modules\Facades\ModuleRegistry::all()->map(fn ($m) => $m->name())->all());
             if (! $module) {
                 $this->components->error('No module selected. Aborting panel creation.');
                 exit(1);

--- a/src/Commands/ModuleMakeFilamentPluginCommand.php
+++ b/src/Commands/ModuleMakeFilamentPluginCommand.php
@@ -50,7 +50,7 @@ class ModuleMakeFilamentPluginCommand extends GeneratorCommand
     public function ensureModule()
     {
         if (! $this->argument('module')) {
-            $module = select('Please select the module to create the plugin in:', \Nwidart\Modules\Facades\Module::allEnabled());
+            $module = select('Please select the module to create the plugin in:', \Coolsam\Modules\Facades\ModuleRegistry::all()->map(fn ($m) => $m->name())->all());
             $this->input->setArgument('module', $module);
         }
     }

--- a/src/Commands/ModuleMakeFilamentResourceCommand.php
+++ b/src/Commands/ModuleMakeFilamentResourceCommand.php
@@ -51,7 +51,7 @@ class ModuleMakeFilamentResourceCommand extends MakeResourceCommand
     public function ensureModuleArgument(): void
     {
         if (! $this->argument('module')) {
-            $module = select('Please select the module to create the resource in:', Module::allEnabled());
+            $module = select('Please select the module to create the resource in:', \Coolsam\Modules\Facades\ModuleRegistry::all()->map(fn ($m) => $m->name())->all());
             if (! $module) {
                 $this->error('No module selected. Aborting resource creation.');
                 exit(1);

--- a/src/Commands/ModuleMakeFilamentWidgetCommand.php
+++ b/src/Commands/ModuleMakeFilamentWidgetCommand.php
@@ -43,7 +43,7 @@ class ModuleMakeFilamentWidgetCommand extends MakeWidgetCommand
     public function ensureModule()
     {
         if (! $this->argument('module')) {
-            $module = select('Please select the module to create the page in:', \Module::allEnabled());
+            $module = select('Please select the module to create the page in:', \Coolsam\Modules\Facades\ModuleRegistry::all()->map(fn ($m) => $m->name())->all());
             if (! $module) {
                 $this->error('No module selected. Aborting page creation.');
                 exit(1);

--- a/src/Concerns/ModuleFilamentPlugin.php
+++ b/src/Concerns/ModuleFilamentPlugin.php
@@ -18,7 +18,7 @@ trait ModuleFilamentPlugin
     {
         $module = $this->getModule();
 
-        if (! $module->isEnabled()) {
+        if (! app(\Coolsam\Modules\Contracts\ModuleActivator::class)->isActive($this->getModuleName())) {
             return;
         }
 

--- a/src/Contracts/DependencyResolver.php
+++ b/src/Contracts/DependencyResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Coolsam\Modules\Contracts;
+
+interface DependencyResolver
+{
+    public function assertCanActivate(ModuleDefinition | string $module, string | int | null $tenantId = null): void;
+
+    public function assertCanDeactivate(ModuleDefinition | string $module, string | int | null $tenantId = null): void;
+
+    /**
+     * @return list<string>
+     */
+    public function activationOrder(ModuleDefinition | string $module): array;
+
+    /**
+     * @return list<string>
+     */
+    public function dependents(ModuleDefinition | string $module, string | int | null $tenantId = null): array;
+}

--- a/src/Contracts/ModuleActivator.php
+++ b/src/Contracts/ModuleActivator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Coolsam\Modules\Contracts;
+
+use Illuminate\Support\Collection;
+
+interface ModuleActivator
+{
+    public function isActive(ModuleDefinition | string $module, string | int | null $tenantId = null): bool;
+
+    /**
+     * @return Collection<int, ModuleDefinition>
+     */
+    public function active(string | int | null $tenantId = null): Collection;
+
+    public function activate(ModuleDefinition | string $module, string | int | null $tenantId = null): void;
+
+    public function deactivate(ModuleDefinition | string $module, string | int | null $tenantId = null): void;
+}

--- a/src/Contracts/ModuleDefinition.php
+++ b/src/Contracts/ModuleDefinition.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Coolsam\Modules\Contracts;
+
+interface ModuleDefinition
+{
+    public function name(): string;
+
+    public function alias(): string;
+
+    public function path(): string;
+
+    /**
+     * @return list<string>
+     */
+    public function dependencies(): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function manifest(): array;
+}

--- a/src/Contracts/ModuleRegistry.php
+++ b/src/Contracts/ModuleRegistry.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Coolsam\Modules\Contracts;
+
+use Illuminate\Support\Collection;
+
+interface ModuleRegistry
+{
+    /**
+     * @return Collection<int, ModuleDefinition>
+     */
+    public function all(): Collection;
+
+    public function find(string $name): ?ModuleDefinition;
+
+    public function exists(string $name): bool;
+}

--- a/src/Contracts/TenantContext.php
+++ b/src/Contracts/TenantContext.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Coolsam\Modules\Contracts;
+
+interface TenantContext
+{
+    public function resolve(): string | int | null;
+}

--- a/src/Dependencies/ModuleDependencyResolver.php
+++ b/src/Dependencies/ModuleDependencyResolver.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Coolsam\Modules\Dependencies;
+
+use Coolsam\Modules\Contracts\DependencyResolver;
+use Coolsam\Modules\Contracts\ModuleActivator;
+use Coolsam\Modules\Contracts\ModuleDefinition;
+use Coolsam\Modules\Contracts\ModuleRegistry;
+use Coolsam\Modules\Exceptions\ModuleIsDependedUponException;
+use Coolsam\Modules\Exceptions\UnsatisfiedDependenciesException;
+use RuntimeException;
+
+class ModuleDependencyResolver implements DependencyResolver
+{
+    public function __construct(
+        protected ModuleRegistry $registry,
+    ) {}
+
+    protected function activator(): ModuleActivator
+    {
+        return app(ModuleActivator::class);
+    }
+
+    public function assertCanActivate(ModuleDefinition | string $module, string | int | null $tenantId = null): void
+    {
+        $definition = $this->resolveDefinition($module);
+        $missing = [];
+
+        foreach ($this->activationOrder($definition) as $dependency) {
+            if ($dependency === $definition->name()) {
+                continue;
+            }
+
+            if (! $this->registry->exists($dependency)) {
+                $missing[] = $dependency;
+            }
+        }
+
+        if ($missing !== []) {
+            throw new UnsatisfiedDependenciesException($definition->name(), array_values(array_unique($missing)));
+        }
+    }
+
+    public function assertCanDeactivate(ModuleDefinition | string $module, string | int | null $tenantId = null): void
+    {
+        $definition = $this->resolveDefinition($module);
+        $dependents = $this->dependents($definition, $tenantId);
+
+        if ($dependents !== []) {
+            throw new ModuleIsDependedUponException($definition->name(), $dependents);
+        }
+    }
+
+    public function activationOrder(ModuleDefinition | string $module): array
+    {
+        $definition = $this->resolveDefinition($module);
+        $order = [];
+        $visited = [];
+
+        $this->walkDependencies($definition->name(), $order, $visited);
+
+        if (! in_array($definition->name(), $order, true)) {
+            $order[] = $definition->name();
+        }
+
+        return $order;
+    }
+
+    public function dependents(ModuleDefinition | string $module, string | int | null $tenantId = null): array
+    {
+        $definition = $this->resolveDefinition($module);
+        $dependents = [];
+
+        foreach ($this->registry->all() as $candidate) {
+            if (! in_array($definition->name(), $candidate->dependencies(), true)) {
+                continue;
+            }
+
+            if (! $this->activator()->isActive($candidate, $tenantId)) {
+                continue;
+            }
+
+            $dependents[] = $candidate->name();
+        }
+
+        return array_values(array_unique($dependents));
+    }
+
+    /**
+     * @param  list<string>  $order
+     * @param  array<string, bool>  $visited
+     */
+    protected function walkDependencies(string $moduleName, array &$order, array &$visited): void
+    {
+        if (isset($visited[$moduleName])) {
+            return;
+        }
+
+        $visited[$moduleName] = true;
+
+        $definition = $this->registry->find($moduleName);
+
+        if (! $definition) {
+            return;
+        }
+
+        foreach ($definition->dependencies() as $dependency) {
+            $this->walkDependencies($dependency, $order, $visited);
+
+            if (! in_array($dependency, $order, true)) {
+                $order[] = $dependency;
+            }
+        }
+    }
+
+    protected function resolveDefinition(ModuleDefinition | string $module): ModuleDefinition
+    {
+        if ($module instanceof ModuleDefinition) {
+            return $module;
+        }
+
+        $definition = $this->registry->find($module);
+
+        if (! $definition) {
+            throw new RuntimeException("Module [{$module}] was not found.");
+        }
+
+        return $definition;
+    }
+}

--- a/src/Drivers/Nwidart/NwidartModuleDefinition.php
+++ b/src/Drivers/Nwidart/NwidartModuleDefinition.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Coolsam\Modules\Drivers\Nwidart;
+
+use Coolsam\Modules\Contracts\ModuleDefinition;
+use Nwidart\Modules\Module;
+
+class NwidartModuleDefinition implements ModuleDefinition
+{
+    public function __construct(
+        protected Module $module,
+    ) {}
+
+    public function module(): Module
+    {
+        return $this->module;
+    }
+
+    public function name(): string
+    {
+        return $this->module->getName();
+    }
+
+    public function alias(): string
+    {
+        return $this->module->getLowerName();
+    }
+
+    public function path(): string
+    {
+        return $this->module->getPath();
+    }
+
+    public function dependencies(): array
+    {
+        $requires = $this->module->get('requires') ?? $this->module->get('depends') ?? [];
+
+        if (! is_array($requires)) {
+            return [];
+        }
+
+        return array_values($requires);
+    }
+
+    public function manifest(): array
+    {
+        return $this->module->json()->getAttributes();
+    }
+}

--- a/src/Drivers/Nwidart/NwidartModuleRegistry.php
+++ b/src/Drivers/Nwidart/NwidartModuleRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Coolsam\Modules\Drivers\Nwidart;
+
+use Coolsam\Modules\Contracts\ModuleDefinition;
+use Coolsam\Modules\Contracts\ModuleRegistry;
+use Illuminate\Support\Collection;
+use Nwidart\Modules\Facades\Module;
+
+class NwidartModuleRegistry implements ModuleRegistry
+{
+    public function all(): Collection
+    {
+        return collect(Module::all())
+            ->map(fn (Module $module) => new NwidartModuleDefinition($module))
+            ->values();
+    }
+
+    public function find(string $name): ?ModuleDefinition
+    {
+        $module = Module::find($name);
+
+        if (! $module) {
+            return null;
+        }
+
+        return new NwidartModuleDefinition($module);
+    }
+
+    public function exists(string $name): bool
+    {
+        return Module::find($name) !== null;
+    }
+}

--- a/src/Exceptions/ModuleIsDependedUponException.php
+++ b/src/Exceptions/ModuleIsDependedUponException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Coolsam\Modules\Exceptions;
+
+use Exception;
+
+class ModuleIsDependedUponException extends Exception
+{
+    /**
+     * @param  list<string>  $dependents
+     */
+    public function __construct(
+        public readonly string $module,
+        public readonly array $dependents,
+    ) {
+        parent::__construct(
+            "Cannot deactivate module [{$module}]. Active dependents: " . implode(', ', $dependents) . '.'
+        );
+    }
+}

--- a/src/Exceptions/UnsatisfiedDependenciesException.php
+++ b/src/Exceptions/UnsatisfiedDependenciesException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Coolsam\Modules\Exceptions;
+
+use Exception;
+
+class UnsatisfiedDependenciesException extends Exception
+{
+    /**
+     * @param  list<string>  $missing
+     */
+    public function __construct(
+        public readonly string $module,
+        public readonly array $missing,
+    ) {
+        parent::__construct(
+            "Cannot activate module [{$module}]. Missing or inactive dependencies: " . implode(', ', $missing) . '.'
+        );
+    }
+}

--- a/src/Facades/ModuleActivator.php
+++ b/src/Facades/ModuleActivator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Coolsam\Modules\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static bool isActive(\Coolsam\Modules\Contracts\ModuleDefinition|string $module, string|int|null $tenantId = null)
+ * @method static \Illuminate\Support\Collection<int, \Coolsam\Modules\Contracts\ModuleDefinition> active(string|int|null $tenantId = null)
+ * @method static void activate(\Coolsam\Modules\Contracts\ModuleDefinition|string $module, string|int|null $tenantId = null)
+ * @method static void deactivate(\Coolsam\Modules\Contracts\ModuleDefinition|string $module, string|int|null $tenantId = null)
+ *
+ * @see \Coolsam\Modules\Contracts\ModuleActivator
+ */
+class ModuleActivator extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return \Coolsam\Modules\Contracts\ModuleActivator::class;
+    }
+}

--- a/src/Facades/ModuleRegistry.php
+++ b/src/Facades/ModuleRegistry.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Coolsam\Modules\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static \Illuminate\Support\Collection<int, \Coolsam\Modules\Contracts\ModuleDefinition> all()
+ * @method static \Coolsam\Modules\Contracts\ModuleDefinition|null find(string $name)
+ * @method static bool exists(string $name)
+ *
+ * @see \Coolsam\Modules\Contracts\ModuleRegistry
+ */
+class ModuleRegistry extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return \Coolsam\Modules\Contracts\ModuleRegistry::class;
+    }
+}

--- a/src/ModulesPlugin.php
+++ b/src/ModulesPlugin.php
@@ -8,6 +8,7 @@ use Filament\Contracts\Plugin;
 use Filament\Navigation\NavigationGroup;
 use Filament\Navigation\NavigationItem;
 use Filament\Panel;
+use Nwidart\Modules\Facades\Module as ModuleFacade;
 
 class ModulesPlugin implements Plugin
 {
@@ -47,7 +48,7 @@ class ModulesPlugin implements Plugin
             ]);
             $navItems = collect($panels)->map(function (Panel $panel) use ($group, $groupSort, $openInNewTab) {
                 $moduleName = str($panel->getPath())->before('/');
-                $module = \Module::find($moduleName);
+                $module = ModuleFacade::find($moduleName);
                 if (! $module) {
                     return null;
                 }
@@ -112,7 +113,7 @@ class ModulesPlugin implements Plugin
             $id = str($class)->afterLast('\\')->before('PanelProvider')->kebab()->lower();
             // get module it belongs to as well
             $moduleName = str($class)->after('Modules\\')->before('\\Providers\\Filament');
-            $module = \Module::find($moduleName);
+            $module = ModuleFacade::find($moduleName);
             if (! $module) {
                 return null;
             }

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -9,7 +9,8 @@ use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Filesystem\Filesystem;
 use Livewire\Features\SupportTesting\Testable;
-use Nwidart\Modules\Module;
+use Nwidart\Modules\Facades\Module as ModuleFacade;
+use Nwidart\Modules\Module as NwidartModule;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -58,8 +59,35 @@ class ModulesServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
+        $this->registerModuleRuntime();
         $this->registerModuleMacros();
         $this->autoDiscoverPanels();
+    }
+
+    protected function registerModuleRuntime(): void
+    {
+        $this->app->singleton(\Coolsam\Modules\Contracts\ModuleRegistry::class, \Coolsam\Modules\Drivers\Nwidart\NwidartModuleRegistry::class);
+
+        $this->app->singleton(\Coolsam\Modules\Contracts\TenantContext::class, function ($app) {
+            $class = config('filament-modules.tenancy.context');
+
+            if (is_string($class) && class_exists($class)) {
+                return $app->make($class);
+            }
+
+            return $app->make(\Coolsam\Modules\Support\DefaultTenantContext::class);
+        });
+
+        $this->app->singleton(\Coolsam\Modules\Contracts\DependencyResolver::class, \Coolsam\Modules\Dependencies\ModuleDependencyResolver::class);
+
+        $this->app->singleton(\Coolsam\Modules\Contracts\ModuleActivator::class, function ($app) {
+            return match (config('filament-modules.activation.driver', 'file')) {
+                'file' => $app->make(\Coolsam\Modules\Activation\FileModuleActivator::class),
+                default => throw new \InvalidArgumentException(
+                    'Unsupported module activation driver [' . config('filament-modules.activation.driver') . '].'
+                ),
+            };
+        });
     }
 
     public function attemptToRegisterModuleProviders(): void
@@ -81,7 +109,7 @@ class ModulesServiceProvider extends PackageServiceProvider
             $namespace = FilamentModules::convertPathToNamespace($provider);
             $module = str($namespace)->before('\Providers\\')->afterLast('\\')->toString();
             $className = str($namespace)->afterLast('\\')->toString();
-            if (str($className)->startsWith($module)) && \Module::isEnabled($module)){
+            if (str($className)->startsWith($module) && app(\Coolsam\Modules\Contracts\ModuleActivator::class)->isActive($module)) {
                 // register the module service provider
                 $this->app->register($namespace);
             }
@@ -91,17 +119,23 @@ class ModulesServiceProvider extends PackageServiceProvider
     public function autoDiscoverPanels(): void
     {
         $this->app->beforeResolving('filament', function () {
-            $modules = \Module::allEnabled();
-            $cacheKey = 'filament-modules-panel-providers';
-            $ttl = 10;  // 24 hours
-            $modules = \Module::allEnabled();
-            $panels = collect($modules)->flatMap(function (Module $module) {
-                $panelProviders = glob($module->getExtraPath('app/Providers/Filament') . '/*.php');
+            $activator = app(\Coolsam\Modules\Contracts\ModuleActivator::class);
+            $panels = app(\Coolsam\Modules\Contracts\ModuleRegistry::class)
+                ->all()
+                ->filter(fn (\Coolsam\Modules\Contracts\ModuleDefinition $module) => $activator->isActive($module))
+                ->flatMap(function (\Coolsam\Modules\Contracts\ModuleDefinition $moduleDefinition) {
+                    $module = ModuleFacade::find($moduleDefinition->name());
 
-                return collect($panelProviders)->map(function ($path) {
-                    return $this->app[Modules::class]->convertPathToNamespace($path);
+                    if (! $module) {
+                        return [];
+                    }
+
+                    $panelProviders = glob($module->getExtraPath('app/Providers/Filament') . '/*.php');
+
+                    return collect($panelProviders)->map(function ($path) {
+                        return $this->app[Modules::class]->convertPathToNamespace($path);
+                    })->toArray();
                 })->toArray();
-            })->toArray();
             foreach ($panels as $panel) {
                 if (class_exists($panel)) {
                     $this->app->register($panel);
@@ -206,7 +240,7 @@ class ModulesServiceProvider extends PackageServiceProvider
 
     protected function registerModuleMacros(): void
     {
-        Module::macro('namespace', function (?string $relativeNamespace = '') {
+        NwidartModule::macro('namespace', function (?string $relativeNamespace = '') {
             $relativeNamespace = $relativeNamespace ?? '';
             $base = trim(config('modules.namespace', 'Modules'), '\\');
             $relativeNamespace = trim($relativeNamespace, '\\');
@@ -215,11 +249,11 @@ class ModulesServiceProvider extends PackageServiceProvider
             return str($base)->append('\\')->append($studlyName)->append('\\')->append($relativeNamespace)->replace('\\\\', '\\')->toString();
         });
 
-        Module::macro('getTitle', function () {
+        NwidartModule::macro('getTitle', function () {
             return str($this->getStudlyName())->kebab()->title()->replace('-', ' ')->toString();
         });
 
-        Module::macro('appNamespace', function (string $relativeNamespace = '') {
+        NwidartModule::macro('appNamespace', function (string $relativeNamespace = '') {
             $prefix = str(config('modules.paths.app_folder', 'app'))->ltrim(DIRECTORY_SEPARATOR, '\\')->studly()->toString();
             $relativeNamespace = trim($relativeNamespace, '\\');
             if (filled($prefix)) {
@@ -229,39 +263,39 @@ class ModulesServiceProvider extends PackageServiceProvider
 
             return $this->namespace($relativeNamespace);
         });
-        Module::macro('appPath', function (string $relativePath = '') {
+        NwidartModule::macro('appPath', function (string $relativePath = '') {
             $appPath = $this->getExtraPath(config('modules.paths.app_folder', 'app'));
 
             return str($appPath . ($relativePath ? DIRECTORY_SEPARATOR . $relativePath : ''))->replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR)->toString();
         });
 
-        Module::macro('databasePath', function (string $relativePath = '') {
+        NwidartModule::macro('databasePath', function (string $relativePath = '') {
             $appPath = $this->getExtraPath('database');
 
             return str($appPath . ($relativePath ? DIRECTORY_SEPARATOR . $relativePath : ''))->replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR)->toString();
         });
 
-        Module::macro('resourcesPath', function (string $relativePath = '') {
+        NwidartModule::macro('resourcesPath', function (string $relativePath = '') {
             $appPath = $this->getExtraPath('resources');
 
             return str($appPath . ($relativePath ? DIRECTORY_SEPARATOR . $relativePath : ''))
                 ->replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR)->toString();
         });
 
-        Module::macro('migrationsPath', function (string $relativePath = '') {
+        NwidartModule::macro('migrationsPath', function (string $relativePath = '') {
             $appPath = $this->databasePath('migrations');
 
             return str($appPath . ($relativePath ? DIRECTORY_SEPARATOR . $relativePath : ''))
                 ->replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR)->toString();
         });
 
-        Module::macro('seedersPath', function (string $relativePath = '') {
+        NwidartModule::macro('seedersPath', function (string $relativePath = '') {
             $appPath = $this->databasePath('seeders');
 
             return str($appPath . ($relativePath ? DIRECTORY_SEPARATOR . $relativePath : ''))->replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR)->toString();
         });
 
-        Module::macro('factoriesPath', function (string $relativePath = '') {
+        NwidartModule::macro('factoriesPath', function (string $relativePath = '') {
             $appPath = $this->databasePath('factories');
 
             return str($appPath . ($relativePath ? DIRECTORY_SEPARATOR . $relativePath : ''))->replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR)->toString();

--- a/src/Support/DefaultTenantContext.php
+++ b/src/Support/DefaultTenantContext.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Coolsam\Modules\Support;
+
+use Coolsam\Modules\Contracts\TenantContext;
+
+class DefaultTenantContext implements TenantContext
+{
+    public function resolve(): string | int | null
+    {
+        return null;
+    }
+}

--- a/src/Traits/CanAccessTrait.php
+++ b/src/Traits/CanAccessTrait.php
@@ -15,9 +15,9 @@ trait CanAccessTrait
 
     public static function canAccess(): bool
     {
-        $isModuleEnabled = \Nwidart\Modules\Facades\Module::find(
+        $isModuleEnabled = app(\Coolsam\Modules\Contracts\ModuleActivator::class)->isActive(
             static::getCurrentModuleName()
-        )?->isEnabled();
+        );
         $parentAccess = function_exists('canAccess') ? parent::canAccess() : true;
 
         if ($isModuleEnabled && $parentAccess) {

--- a/tests/Unit/ModuleDependencyResolverTest.php
+++ b/tests/Unit/ModuleDependencyResolverTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use Coolsam\Modules\Contracts\ModuleActivator;
+use Coolsam\Modules\Contracts\ModuleDefinition;
+use Coolsam\Modules\Contracts\ModuleRegistry;
+use Coolsam\Modules\Dependencies\ModuleDependencyResolver;
+use Coolsam\Modules\Exceptions\ModuleIsDependedUponException;
+use Coolsam\Modules\Exceptions\UnsatisfiedDependenciesException;
+
+function makeModuleDefinition(string $name, array $dependencies = []): ModuleDefinition
+{
+    return new class($name, $dependencies) implements ModuleDefinition
+    {
+        public function __construct(
+            private string $name,
+            private array $dependencies,
+        ) {}
+
+        public function name(): string
+        {
+            return $this->name;
+        }
+
+        public function alias(): string
+        {
+            return strtolower($this->name);
+        }
+
+        public function path(): string
+        {
+            return '/modules/' . $this->name;
+        }
+
+        public function dependencies(): array
+        {
+            return $this->dependencies;
+        }
+
+        public function manifest(): array
+        {
+            return ['name' => $this->name, 'requires' => $this->dependencies];
+        }
+    };
+}
+
+test('activation order resolves dependencies first', function () {
+    $registry = Mockery::mock(ModuleRegistry::class);
+    $registry->shouldReceive('find')->with('Core')->andReturn(makeModuleDefinition('Core'));
+    $registry->shouldReceive('find')->with('Blog')->andReturn(makeModuleDefinition('Blog', ['Core']));
+    $registry->shouldReceive('find')->with('Shop')->andReturn(makeModuleDefinition('Shop', ['Blog']));
+
+    $resolver = new ModuleDependencyResolver($registry);
+
+    expect($resolver->activationOrder('Shop'))->toBe(['Core', 'Blog', 'Shop']);
+});
+
+test('cannot activate a module with missing dependencies', function () {
+    $registry = Mockery::mock(ModuleRegistry::class);
+    $registry->shouldReceive('find')->with('Shop')->andReturn(makeModuleDefinition('Shop', ['Missing']));
+    $registry->shouldReceive('find')->with('Missing')->andReturnNull();
+    $registry->shouldReceive('exists')->with('Missing')->andReturnFalse();
+
+    $resolver = new ModuleDependencyResolver($registry);
+
+    $resolver->assertCanActivate('Shop');
+})->throws(UnsatisfiedDependenciesException::class);
+
+test('cannot deactivate a module with active dependents', function () {
+    $registry = Mockery::mock(ModuleRegistry::class);
+    $registry->shouldReceive('find')->with('Blog')->andReturn(makeModuleDefinition('Blog'));
+    $registry->shouldReceive('all')->andReturn(collect([
+        makeModuleDefinition('Blog'),
+        makeModuleDefinition('Shop', ['Blog']),
+    ]));
+
+    $activator = Mockery::mock(ModuleActivator::class);
+    $activator->shouldReceive('isActive')->with('Blog', null)->andReturnTrue();
+    $activator->shouldReceive('isActive')->with(Mockery::type(ModuleDefinition::class), null)->andReturnUsing(
+        fn (ModuleDefinition $module) => $module->name() === 'Shop'
+    );
+    app()->instance(ModuleActivator::class, $activator);
+
+    $resolver = new ModuleDependencyResolver($registry);
+
+    $resolver->assertCanDeactivate('Blog');
+})->throws(ModuleIsDependedUponException::class);
+
+test('returns active dependents for a module', function () {
+    $registry = Mockery::mock(ModuleRegistry::class);
+    $registry->shouldReceive('find')->with('Blog')->andReturn(makeModuleDefinition('Blog'));
+    $registry->shouldReceive('all')->andReturn(collect([
+        makeModuleDefinition('Blog'),
+        makeModuleDefinition('Shop', ['Blog']),
+        makeModuleDefinition('Reports', ['Blog']),
+    ]));
+
+    $activator = Mockery::mock(ModuleActivator::class);
+    $activator->shouldReceive('isActive')->andReturnUsing(
+        fn (ModuleDefinition | string $module) => in_array(
+            is_string($module) ? $module : $module->name(),
+            ['Shop'],
+            true
+        )
+    );
+    app()->instance(ModuleActivator::class, $activator);
+
+    $resolver = new ModuleDependencyResolver($registry);
+
+    expect($resolver->dependents('Blog'))->toBe(['Shop']);
+});


### PR DESCRIPTION
## Summary

- Introduces driver-agnostic module runtime contracts (`ModuleRegistry`, `ModuleActivator`, `DependencyResolver`, `TenantContext`) with an nwidart discovery driver and file-based activator for backward compatibility.
- Refactors the package to route activation checks through `ModuleActivator` instead of nwidart disk status directly.
- Adds dependency resolution (activation order, enable guards, deactivate guards) and unit tests.
- Adds `V6-ROADMAP.md` documenting the v6 architecture, branch strategy, and milestones.
- Extends CI to run tests on `5.x` and `feature/**` branches.

## Test plan

- [x] `vendor/bin/pest --ci` passes locally on `feature/v6-module-runtime` (8 tests)
- [ ] CI green on this PR
- [ ] Single-tenant apps continue to use file activator (`modules_statuses.json`) with no config changes required


Made with [Cursor](https://cursor.com)