### PR TITLE
docs: point CI badge at 5.x and use for-the-badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Filament Modules v5.x
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/coolsam/modules.svg?style=flat-square)](https://packagist.org/packages/coolsam/modules)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/coolsam726/filament-modules/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/coolsam726/filament-modules/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![Total Downloads](https://img.shields.io/packagist/dt/coolsam/modules.svg?style=flat-square)](https://packagist.org/packages/coolsam/modules)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/coolsam/modules.svg?style=for-the-badge)](https://packagist.org/packages/coolsam/modules)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/coolsam726/filament-modules/run-tests.yml?branch=5.x&label=tests&style=for-the-badge)](https://github.com/coolsam726/filament-modules/actions?query=workflow%3Arun-tests+branch%3A5.x)
+[![Total Downloads](https://img.shields.io/packagist/dt/coolsam/modules.svg?style=for-the-badge)](https://packagist.org/packages/coolsam/modules)
 
 > **NOTE:** This documentation is for **version 5.x** of the package, which supports **Laravel 11+**, **Filament 4.x**
 > and


### PR DESCRIPTION
## Summary
- Point the tests workflow badge and link at the `5.x` branch instead of `main`
- Switch Packagist and CI badges to `for-the-badge` style

## Test plan
- [ ] Badges render correctly on the README preview