### PR TITLE
fix: custom namespace providers, panel names, and theme command

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,18 @@ php artisan module:filament:make-panel
 ```
 Follow the interactive prompts to create a new panel in your module.
 
+### Scoping resources, clusters, and pages to a panel
+
+Each module can register one or more Filament panels through `module:make:filament-panel`. Resources, pages, widgets, and clusters belong to a panel through that panel's `PanelProvider` — typically via `discoverResources()`, `discoverPages()`, and `discoverWidgets()` inside the provider's `panel()` method.
+
+To keep a resource or cluster in a single panel:
+
+1. Generate the resource/cluster inside the target module (and panel subdirectory, if you use per-panel folders).
+2. Ensure only the intended module `*PanelProvider` discovers that directory/namespace.
+3. Register `ModulesPlugin` on the main/admin panel so module panel links appear in navigation when `filament-modules.mode` supports panels.
+
+Filament's own panel discovery rules apply; this package wires modules and panels together but does not override Filament's per-panel registration model.
+
 
 ### Protecting your resources, pages and widgets (Access Control) - WIP
 

--- a/src/Commands/ModuleMakeFilamentThemeCommand.php
+++ b/src/Commands/ModuleMakeFilamentThemeCommand.php
@@ -18,6 +18,8 @@ class ModuleMakeFilamentThemeCommand extends MakeThemeCommand
 
     public function handle(Filesystem $filesystem): int
     {
+        $this->filesystem = $filesystem;
+
         $module = $this->getModule();
 
         $this->call('vendor:publish', [

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -91,6 +91,54 @@ class Modules
             ->implode('\\');
     }
 
+    public function findModuleNameForPath(string $path): ?string
+    {
+        $normalizedPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+        $modulesPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, config('modules.paths.modules', base_path('Modules')));
+
+        $directory = is_file($normalizedPath) ? dirname($normalizedPath) : $normalizedPath;
+
+        while (str($directory)->startsWith($modulesPath) && $directory !== $modulesPath) {
+            $moduleJsonPath = $directory . DIRECTORY_SEPARATOR . 'module.json';
+
+            if (is_file($moduleJsonPath)) {
+                $moduleJson = json_decode((string) file_get_contents($moduleJsonPath), true);
+
+                return is_array($moduleJson) ? ($moduleJson['name'] ?? basename($directory)) : basename($directory);
+            }
+
+            $parentDirectory = dirname($directory);
+
+            if ($parentDirectory === $directory) {
+                break;
+            }
+
+            $directory = $parentDirectory;
+        }
+
+        return null;
+    }
+
+    public function resolveClassFromProviderFile(string $providerPath): ?string
+    {
+        if (! is_file($providerPath)) {
+            return null;
+        }
+
+        $content = file_get_contents($providerPath);
+
+        if ($content === false || ! preg_match('/^namespace\s+([^;]+);/m', $content, $matches)) {
+            return null;
+        }
+
+        return trim($matches[1]) . '\\' . basename($providerPath, '.php');
+    }
+
+    public function resolveProviderClass(string $providerPath): string
+    {
+        return $this->resolveClassFromProviderFile($providerPath) ?? $this->convertPathToNamespace($providerPath);
+    }
+
     public function execCommand(string $command, ?Command $artisan = null): void
     {
         $process = Process::fromShellCommandline($command);

--- a/src/ModulesPlugin.php
+++ b/src/ModulesPlugin.php
@@ -109,15 +109,21 @@ class ModulesPlugin implements Plugin
         $pattern = $basePath . DIRECTORY_SEPARATOR . '*' . DIRECTORY_SEPARATOR . $appFolder . DIRECTORY_SEPARATOR . 'Providers' . DIRECTORY_SEPARATOR . 'Filament' . DIRECTORY_SEPARATOR . '*.php';
         $panelPaths = glob($pattern);
 
-        $panelIds = collect($panelPaths)->map(fn ($path) => FilamentModules::convertPathToNamespace($path))->map(function ($class) {
-            // Get the panel ID and check if it is registered
-            $id = str($class)->afterLast('\\')->before('PanelProvider')->kebab()->lower();
-            // get module it belongs to as well
-            $moduleName = str($class)->after('Modules\\')->before('\\Providers\\Filament');
-            $module = ModuleFacade::find($moduleName);
+        $panelIds = collect($panelPaths)->map(function ($path) {
+            $class = FilamentModules::resolveProviderClass($path);
+
+            if (! class_exists($class)) {
+                return null;
+            }
+
+            $moduleName = FilamentModules::findModuleNameForPath($path);
+            $module = $moduleName ? ModuleFacade::find($moduleName) : null;
+
             if (! $module) {
                 return null;
             }
+
+            $id = str($class)->afterLast('\\')->before('PanelProvider')->kebab()->lower();
 
             return str($id)->prepend('-')->prepend($module->getKebabName());
         });

--- a/src/ModulesServiceProvider.php
+++ b/src/ModulesServiceProvider.php
@@ -79,11 +79,17 @@ class ModulesServiceProvider extends PackageServiceProvider
         $providers = array_merge($serviceProviders, $panelProviders);
 
         foreach ($providers as $provider) {
-            $namespace = FilamentModules::convertPathToNamespace($provider);
-            $module = str($namespace)->before('\Providers\\')->afterLast('\\')->toString();
+            $namespace = FilamentModules::resolveProviderClass($provider);
+            $moduleName = FilamentModules::findModuleNameForPath($provider);
+
+            if (! $moduleName || ! ModuleFacade::isEnabled($moduleName)) {
+                continue;
+            }
+
             $className = str($namespace)->afterLast('\\')->toString();
-            if (str($className)->startsWith($module) && ModuleFacade::isEnabled($module)) {
-                // register the module service provider
+            $moduleStudlyName = str($moduleName)->studly()->toString();
+
+            if (str($className)->startsWith($moduleStudlyName) && class_exists($namespace)) {
                 $this->app->register($namespace);
             }
         }

--- a/tests/Unit/ModuleProviderResolutionTest.php
+++ b/tests/Unit/ModuleProviderResolutionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Coolsam\Modules\Facades\FilamentModules;
+
+test('can resolve provider class from file namespace declaration', function () {
+    $module = $this->createTestModule('CustomNsModule');
+
+    $providerPath = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'CustomNamespaceServiceProvider.php');
+    $providerDir = dirname($providerPath);
+
+    if (! is_dir($providerDir)) {
+        mkdir($providerDir, 0755, true);
+    }
+
+    file_put_contents($providerPath, <<<'PHP'
+<?php
+
+namespace MyCompany\CRM\Blog\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class CustomNamespaceServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+}
+PHP);
+
+    expect(FilamentModules::resolveClassFromProviderFile($providerPath))
+        ->toBe('MyCompany\\CRM\\Blog\\Providers\\CustomNamespaceServiceProvider');
+    expect(FilamentModules::resolveProviderClass($providerPath))
+        ->toBe('MyCompany\\CRM\\Blog\\Providers\\CustomNamespaceServiceProvider');
+});
+
+test('can find module name from provider path regardless of namespace', function () {
+    $module = $this->createTestModule('PathLookupModule');
+
+    $providerPath = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'BlogServiceProvider.php');
+
+    expect(FilamentModules::findModuleNameForPath($providerPath))->toBe('PathLookupModule');
+});
+
+test('registers providers that declare custom namespaces when enabled', function () {
+    $module = $this->createTestModule('CustomProviderModule', enabled: true);
+
+    $providerPath = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'BlogServiceProvider.php');
+    $providerDir = dirname($providerPath);
+
+    if (! is_dir($providerDir)) {
+        mkdir($providerDir, 0755, true);
+    }
+
+    file_put_contents($providerPath, <<<'PHP'
+<?php
+
+namespace MyCompany\CRM\Blog\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class BlogServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+}
+PHP);
+
+    $namespace = FilamentModules::resolveProviderClass($providerPath);
+
+    expect(FilamentModules::findModuleNameForPath($providerPath))->toBe('CustomProviderModule');
+    expect(str($namespace)->afterLast('\\')->startsWith('Blog'))->toBeTrue();
+
+    require_once $providerPath;
+
+    $this->app->register($namespace);
+
+    expect(collect($this->app->getProviders($namespace)))->not->toBeEmpty();
+});

--- a/tests/Unit/ModulesServiceProviderBootTest.php
+++ b/tests/Unit/ModulesServiceProviderBootTest.php
@@ -20,19 +20,19 @@ test('modules service provider can register enabled module providers discovered 
     }
 
     file_put_contents($providerPath, <<<'PHP'
-        <?php
+<?php
 
-        namespace Modules\Blog\Providers;
+namespace Modules\Blog\Providers;
 
-        use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\ServiceProvider;
 
-        class BlogServiceProvider extends ServiceProvider
-        {
-            public function register(): void
-            {
-            }
-        }
-        PHP);
+class BlogServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+}
+PHP);
 
     require_once $providerPath;
 


### PR DESCRIPTION
## Summary

- **Closes #154** — Provider auto-registration now reads the `namespace` declaration from each provider PHP file (with path-based fallback) and resolves the module name from `module.json` instead of inferring it from the namespace.
- **Closes #155** — `ModulesPlugin::getModulePanels()` uses the same resolution logic, so module names like `Blog` are no longer confused with segments such as `App` in custom namespaces (e.g. `Blog\App\Providers\BlogPanelProvider`).
- **Closes #160** — `ModuleMakeFilamentThemeCommand::handle()` assigns the injected `Filesystem` instance before use.
- **Closes #157** — Documents how to scope resources, clusters, and pages to a specific Filament panel.

### #170 (Laravel 13)

Not addressed on `5.x`. This maintenance branch targets Laravel 11–12 with Filament 4/5 and nwidart 11–13. Laravel 13 support is planned for v6 on `main` per `V6-ROADMAP.md`.

## Test plan

- [x] `vendor/bin/pest --ci` (20 tests)
- [x] `vendor/bin/pint`
- [x] `./vendor/bin/phpstan analyse`
- [x] New `ModuleProviderResolutionTest` covers custom namespaces, path lookup, and provider registration


Made with [Cursor](https://cursor.com)