### PR TITLE
feat: add Laravel 13 support on 5.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,18 @@ jobs:
             testbench: ^10.0
             os: ubuntu-latest
           - php: '8.3'
+            laravel: ^13.10
+            testbench: ^11.0
+            pest-plugin-laravel: ^4.0
+            pest-plugin-livewire: ^4.0
+            os: ubuntu-latest
+          - php: '8.4'
+            laravel: ^13.10
+            testbench: ^11.0
+            pest-plugin-laravel: ^4.0
+            pest-plugin-livewire: ^4.0
+            os: ubuntu-latest
+          - php: '8.3'
             laravel: ^11.0
             testbench: ^9.12
             os: windows-latest
@@ -58,12 +70,20 @@ jobs:
         env:
           COMPOSER_PROCESS_TIMEOUT: 0
         run: |
-          composer require \
-            "laravel/framework:${{ matrix.laravel }}" \
-            "orchestra/testbench:${{ matrix.testbench }}" \
-            --dev \
-            --no-interaction \
-            --no-update
+          PACKAGES=(
+            "laravel/framework:${{ matrix.laravel }}"
+            "orchestra/testbench:${{ matrix.testbench }}"
+          )
+
+          if [ -n "${{ matrix.pest-plugin-laravel }}" ]; then
+            PACKAGES+=("pestphp/pest-plugin-laravel:${{ matrix.pest-plugin-laravel }}")
+          fi
+
+          if [ -n "${{ matrix.pest-plugin-livewire }}" ]; then
+            PACKAGES+=("pestphp/pest-plugin-livewire:${{ matrix.pest-plugin-livewire }}")
+          fi
+
+          composer require "${PACKAGES[@]}" --dev --no-interaction --no-update
           composer update --prefer-stable --prefer-dist --no-interaction --no-scripts
           composer dump-autoload
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/coolsam726/filament-modules/run-tests.yml?branch=5.x&label=tests&style=for-the-badge)](https://github.com/coolsam726/filament-modules/actions?query=workflow%3Arun-tests+branch%3A5.x)
 [![Total Downloads](https://img.shields.io/packagist/dt/coolsam/modules.svg?style=for-the-badge)](https://packagist.org/packages/coolsam/modules)
 
-> **NOTE:** This documentation is for **version 5.x** of the package, which supports **Laravel 11+**, **Filament 4.x**
+> **NOTE:** This documentation is for **version 5.x** of the package, which supports **Laravel 11, 12, and 13**, **Filament 4.x and 5.x**
 > and
 **nwidart/laravel-modules 11+**. If you are using Filament 3.x, please refer
 > to [4.x documentation](https://github.com/coolsam726/filament-modules/tree/4.x)
@@ -38,16 +38,16 @@ The following is a table showing a matrix of supported filament and laravel vers
 
 | Package Version | Laravel Version | Filament Version | nwidart/laravel-modules Version |
 |-----------------|-----------------|------------------|---------------------------------|
-| 5.x             | 11.x and 12.x   | 4.x              | 11.x or 12.x                    |
+| 5.x             | 11.x, 12.x, and 13.x | 4.x and 5.x | 11.x, 12.x, or 13.x             |
 | 4.x             | 11.x and 12.x   | 3.x              | 11.x or 12.x                    |
 | 3.x             | 10.x            | 3.x              | 11.x                            |
 
 v5.x of this package requires the following dependencies:
 
-- Laravel 11.x or 12.x
-- Filament 4.x or higher
-- PHP 8.2 or higher
-- nwidart/laravel-modules 11.x or 12.x
+- Laravel 11.x, 12.x, or 13.x
+- Filament 4.x or 5.x
+- PHP 8.3 or higher
+- nwidart/laravel-modules 11.x, 12.x, or 13.x
 
 ## Installation
 
@@ -57,10 +57,9 @@ You can install the package via composer:
 composer require coolsam/modules
 ```
 
-This will automatically install `nwidart/laravel-modules: ^11` (for Laravel 11) or `nwidart/laravel-modules: ^12` (for
-Laravel 12) as well. Make sure you go through
-the [documentation](https://laravelmodules.com/docs/12) to understand how to use the package and to configure it
-properly before proceeding.
+This will automatically install a compatible `nwidart/laravel-modules` release (`^11` on Laravel 11, `^12` on Laravel 12,
+or `^13` on Laravel 13). Make sure you go through the [documentation](https://laravelmodules.com/docs/v13) to
+understand how to use the package and to configure it properly before proceeding.
 
 **Task: Configure your Laravel Modules first before continuing.**
 

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     ],
     "analyse": "vendor/bin/phpstan analyse",
     "test": "vendor/bin/pest",
-    "test-coverage": "vendor/bin/pest --coverage",
+    "test-coverage": "vendor/bin/pest --coverage --coverage-html=build/coverage --coverage-text=build/coverage.txt --coverage-clover=build/logs/clover.xml",
     "format": "vendor/bin/pint",
     "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
     "prepare": "@php vendor/bin/testbench package:discover --ansi",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
   "require": {
     "php": "^8.3",
     "filament/filament": "^4.0|^5.0",
+    "illuminate/contracts": "^11.28|^12.0|^13.0",
     "nwidart/laravel-modules": "^11.0|^12.0|^13.0",
     "spatie/laravel-package-tools": "^1.15.0"
   },
@@ -30,9 +31,9 @@
     "barryvdh/laravel-ide-helper": "^3.5",
     "laravel/pint": "^1.0",
     "nunomaduro/larastan": "^3.1.0",
-    "orchestra/testbench": "^9.12",
-    "pestphp/pest-plugin-laravel": "^3.1",
-    "pestphp/pest-plugin-livewire": "^3.0",
+    "orchestra/testbench": "^9.12|^10.0|^11.0",
+    "pestphp/pest-plugin-laravel": "^3.1|^4.0",
+    "pestphp/pest-plugin-livewire": "^3.0|^4.0",
     "phpstan/extension-installer": "^1.4.3",
     "spatie/laravel-ray": "^1.39"
   },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require-dev": {
     "barryvdh/laravel-ide-helper": "^3.5",
     "laravel/pint": "^1.0",
-    "nunomaduro/larastan": "^3.1.0",
+    "larastan/larastan": "^3.1.0",
     "orchestra/testbench": "^9.12|^10.0|^11.0",
     "pestphp/pest-plugin-laravel": "^3.1|^4.0",
     "pestphp/pest-plugin-livewire": "^3.0|^4.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,13 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>


### PR DESCRIPTION
## Summary

- **Closes #170** — Adds explicit `illuminate/contracts` support for Laravel 13 alongside Filament 4/5 and nwidart 11–13.
- Extends the CI matrix with PHP 8.3/8.4 on Laravel `^13.10`, Orchestra Testbench `^11`, and Pest 4 plugins.
- Updates README compatibility table and installation notes for Laravel 13 / nwidart 13.

## Notes

- Testbench Core 11 requires Laravel `>=13.10`, so the CI matrix uses `^13.10` rather than `^13.0`.
- Local dev dependencies remain flexible (`testbench` / Pest 3 or 4); CI pins the Laravel version per matrix row as before.

## Test plan

- [x] `vendor/bin/pest --ci` on Laravel 11 baseline (20 tests)
- [x] `vendor/bin/pint` and `./vendor/bin/phpstan analyse`
- [x] Verified consumer install: `laravel/framework:^13.10` + `filament/filament:^5.5` + `nwidart/laravel-modules:^13.0` + `coolsam/modules` resolves successfully


Made with [Cursor](https://cursor.com)