### PR TITLE
ci: add Codecov workflow and coverage badge

### DIFF
--- a/.github/workflows/run-coverage.yml
+++ b/.github/workflows/run-coverage.yml
@@ -1,0 +1,54 @@
+name: run-coverage
+
+on:
+  push:
+    branches: [ main, 5.x ]
+  pull_request:
+    branches: [ main, 5.x ]
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Code coverage
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv, fileinfo
+          coverage: pcov
+          tools: composer:v2
+
+      - name: Install dependencies
+        env:
+          COMPOSER_PROCESS_TIMEOUT: 0
+        run: |
+          composer require \
+            "laravel/framework:^12.0" \
+            "orchestra/testbench:^10.0" \
+            --dev \
+            --no-interaction \
+            --no-update
+          composer update --prefer-stable --prefer-dist --no-interaction --no-scripts
+          composer dump-autoload
+
+      - name: Run tests with coverage
+        run: |
+          mkdir -p build/logs
+          vendor/bin/pest --ci --coverage --coverage-clover=build/logs/clover.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/logs/clover.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/coolsam/modules.svg?style=for-the-badge)](https://packagist.org/packages/coolsam/modules)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/coolsam726/filament-modules/run-tests.yml?branch=5.x&label=tests&style=for-the-badge)](https://github.com/coolsam726/filament-modules/actions?query=workflow%3Arun-tests+branch%3A5.x)
+[![Codecov](https://img.shields.io/codecov/c/github/coolsam726/filament-modules/5.x?style=for-the-badge&logo=codecov)](https://app.codecov.io/gh/coolsam726/filament-modules/tree/5.x)
 [![Total Downloads](https://img.shields.io/packagist/dt/coolsam/modules.svg?style=for-the-badge)](https://packagist.org/packages/coolsam/modules)
 
 > **NOTE:** This documentation is for **version 5.x** of the package, which supports **Laravel 11, 12, and 13**, **Filament 4.x and 5.x**

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project: off
+    patch: off
+
+comment:
+  require_changes: true


### PR DESCRIPTION
## Summary

- Adds a `run-coverage` workflow (PHP 8.4, Laravel 12, pcov) that uploads Clover reports to Codecov.
- Adds a Codecov badge to the README (matching the existing `for-the-badge` shield style).
- Adds `codecov.yml` to keep PR noise low (no required status checks).

## Setup after merge

1. Sign in at [codecov.io](https://codecov.io) with GitHub and enable `coolsam726/filament-modules`.
2. Add the repository upload token as a GitHub Actions secret named `CODECOV_TOKEN`.
3. Re-run the coverage workflow on `5.x` — the badge will populate after the first successful upload.

## Test plan

- [x] `vendor/bin/pest --ci --coverage --coverage-clover=build/logs/clover.xml` locally
- [ ] Merge and verify `run-coverage` workflow on `5.x`