### PR TITLE
chore: disable Cursor PR attribution

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,5 @@
+{
+  "attribution": {
+    "attributePRsToAgent": false
+  }
+}

--- a/.cursor/rules/pull-requests.mdc
+++ b/.cursor/rules/pull-requests.mdc
@@ -1,0 +1,11 @@
+---
+description: Do not add Cursor branding to pull requests
+alwaysApply: true
+---
+
+# Pull requests
+
+When creating or editing GitHub pull request descriptions (`gh pr create`, `gh pr edit`):
+
+- Do **not** append "Made with Cursor", "Made with [Cursor](https://cursor.com)", or any similar agent/IDE attribution footer.
+- PR bodies should contain only the summary, notes, and test plan relevant to the change.


### PR DESCRIPTION
## Summary

- Adds `.cursor/cli.json` with `attributePRsToAgent: false` for this repo.
- Adds an agent rule instructing not to append "Made with Cursor" footers to PR descriptions.