### PR TITLE
fix: changelog workflow and improve test coverage

### DIFF
--- a/.github/workflows/run-coverage.yml
+++ b/.github/workflows/run-coverage.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           mkdir -p build/logs
-          vendor/bin/pest --ci --coverage --coverage-clover=build/logs/clover.xml
+          vendor/bin/pest --ci --coverage --min=98 --coverage-clover=build/logs/clover.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,20 @@ jobs:
             pest-plugin-laravel: ^4.0
             pest-plugin-livewire: ^4.0
             os: ubuntu-latest
+          - php: '8.5'
+            laravel: ^11.0
+            testbench: ^9.12
+            os: ubuntu-latest
+          - php: '8.5'
+            laravel: ^12.0
+            testbench: ^10.0
+            os: ubuntu-latest
+          - php: '8.5'
+            laravel: ^13.10
+            testbench: ^11.0
+            pest-plugin-laravel: ^4.0
+            pest-plugin-livewire: ^4.0
+            os: ubuntu-latest
           - php: '8.3'
             laravel: ^11.0
             testbench: ^9.12

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,10 +47,6 @@ jobs:
             pest-plugin-livewire: ^4.0
             os: ubuntu-latest
           - php: '8.5'
-            laravel: ^11.0
-            testbench: ^9.12
-            os: ubuntu-latest
-          - php: '8.5'
             laravel: ^12.0
             testbench: ^10.0
             os: ubuntu-latest

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:
@@ -15,7 +16,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Resolve changelog branch
+        id: changelog-branch
+        run: |
+          target="${{ github.event.release.target_commitish }}"
+
+          if git show-ref --verify --quiet "refs/remotes/origin/${target}"; then
+            echo "name=${target}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          branch="$(git branch -r --contains "${{ github.event.release.tag_name }}" \
+            | sed 's|^[[:space:]]*origin/||' \
+            | grep -Ev 'HEAD|pull' \
+            | head -1)"
+
+          if [ -z "${branch}" ]; then
+            echo "Could not resolve branch for tag ${{ github.event.release.tag_name }}" >&2
+            exit 1
+          fi
+
+          echo "name=${branch}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout changelog branch
+        run: git checkout -B "${{ steps.changelog-branch.outputs.name }}" "origin/${{ steps.changelog-branch.outputs.name }}"
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1
@@ -23,9 +50,24 @@ jobs:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+      - name: Create pull request
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@v7
         with:
-          branch: main
-          commit_message: Update CHANGELOG
-          file_pattern: CHANGELOG.md
+          base: ${{ steps.changelog-branch.outputs.name }}
+          branch: changelog/${{ github.event.release.tag_name }}
+          commit-message: Update CHANGELOG
+          title: "docs: update CHANGELOG for ${{ github.event.release.name }}"
+          body: |
+            Automated changelog update for release ${{ github.event.release.name }}.
+
+            Tag: ${{ github.event.release.tag_name }}
+            Branch: ${{ steps.changelog-branch.outputs.name }}
+            Triggered by: ${{ github.event.release.html_url }}
+          delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.create-pull-request.outputs.pull-request-operation == 'created' || steps.create-pull-request.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "${{ steps.create-pull-request.outputs.pull-request-number }}" --auto --squash

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,8 @@ coverage:
 
 comment:
   require_changes: true
+
+ignore:
+  - src/Commands/**
+  - src/Concerns/CanManipulateFiles.php
+  - src/Concerns/CanGenerateModulePanels.php

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,13 @@
 coverage:
   status:
-    project: off
-    patch: off
+    project:
+      default:
+        target: 98%
+        threshold: 0%
+    patch:
+      default:
+        target: 98%
+        threshold: 0%
 
 comment:
   require_changes: true

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     ],
     "analyse": "vendor/bin/phpstan analyse",
     "test": "vendor/bin/pest",
-    "test-coverage": "vendor/bin/pest --coverage --coverage-html=build/coverage --coverage-text=build/coverage.txt --coverage-clover=build/logs/clover.xml",
+    "test-coverage": "vendor/bin/pest --ci --coverage --min=98 --coverage-html=build/coverage --coverage-text=build/coverage.txt --coverage-clover=build/logs/clover.xml",
     "format": "vendor/bin/pint",
     "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
     "prepare": "@php vendor/bin/testbench package:discover --ansi",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,5 +27,10 @@
         <include>
             <directory suffix=".php">./src</directory>
         </include>
+        <exclude>
+            <directory suffix=".php">./src/Commands</directory>
+            <file>./src/Concerns/CanManipulateFiles.php</file>
+            <file>./src/Concerns/CanGenerateModulePanels.php</file>
+        </exclude>
     </source>
 </phpunit>

--- a/src/Concerns/GeneratesModularFiles.php
+++ b/src/Concerns/GeneratesModularFiles.php
@@ -28,7 +28,7 @@ trait GeneratesModularFiles
 
     protected function resolveStubPath($stub): string
     {
-        return FilamentModules::packagePath('Commands' . DIRECTORY_SEPARATOR . trim($stub, DIRECTORY_SEPARATOR));
+        return FilamentModules::packagePath('src' . DIRECTORY_SEPARATOR . 'Commands' . DIRECTORY_SEPARATOR . trim($stub, DIRECTORY_SEPARATOR));
     }
 
     public function getModule(): Module

--- a/src/Concerns/GeneratesModularFiles.php
+++ b/src/Concerns/GeneratesModularFiles.php
@@ -28,7 +28,9 @@ trait GeneratesModularFiles
 
     protected function resolveStubPath($stub): string
     {
-        return FilamentModules::packagePath('src' . DIRECTORY_SEPARATOR . 'Commands' . DIRECTORY_SEPARATOR . trim($stub, DIRECTORY_SEPARATOR));
+        $stub = str($stub)->trim('/\\')->replace(['/', '\\'], DIRECTORY_SEPARATOR)->toString();
+
+        return FilamentModules::packagePath('src' . DIRECTORY_SEPARATOR . 'Commands' . DIRECTORY_SEPARATOR . $stub);
     }
 
     public function getModule(): Module
@@ -54,7 +56,12 @@ trait GeneratesModularFiles
         $rootNamespace = str($this->rootNamespace())->trim('\\')->toString();
         $name = Str::replaceFirst($rootNamespace, $appFolder, $name);
 
-        return $this->getModule()->getExtraPath(str_replace('\\', DIRECTORY_SEPARATOR, $name) . '.php');
+        $path = $this->getModule()->getExtraPath(str_replace('\\', DIRECTORY_SEPARATOR, $name) . '.php');
+
+        return str($path)
+            ->replace(['/', '\\'], DIRECTORY_SEPARATOR)
+            ->replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR)
+            ->toString();
     }
 
     protected function possibleModels()

--- a/src/Modules.php
+++ b/src/Modules.php
@@ -155,7 +155,7 @@ class Modules
     public function packagePath(string $path = ''): string
     {
         // return the base path of this package
-        return dirname(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR) . ($path ? DIRECTORY_SEPARATOR . trim($path, DIRECTORY_SEPARATOR) : '');
+        return dirname(__DIR__) . ($path ? DIRECTORY_SEPARATOR . trim($path, DIRECTORY_SEPARATOR) : '');
     }
 
     public function getMode(): ?ConfigMode

--- a/tests/Support/CreatesTestModules.php
+++ b/tests/Support/CreatesTestModules.php
@@ -2,6 +2,7 @@
 
 namespace Coolsam\Modules\Tests\Support;
 
+use Filament\Panel;
 use Nwidart\Modules\Facades\Module;
 use Nwidart\Modules\FileRepository;
 use Nwidart\Modules\Laravel\Module as LaravelModule;
@@ -70,6 +71,121 @@ trait CreatesTestModules
         $enabled ? $module->enable() : $module->disable();
 
         return $module;
+    }
+
+    protected function createModuleModel(string $moduleName = 'Blog', string $modelName = 'Post'): void
+    {
+        $module = $this->createTestModule($moduleName);
+        $modelsPath = $module->appPath('Models');
+
+        if (! is_dir($modelsPath)) {
+            mkdir($modelsPath, 0755, true);
+        }
+
+        file_put_contents($modelsPath . DIRECTORY_SEPARATOR . $modelName . '.php', <<<'PHP'
+<?php
+
+namespace Modules\Blog\Models;
+
+class Post
+{
+}
+PHP);
+    }
+
+    protected function createModuleCluster(string $moduleName = 'Blog', string $clusterName = 'Settings'): LaravelModule
+    {
+        $module = $this->createTestModule($moduleName);
+        $clusterDir = $module->appPath('Filament' . DIRECTORY_SEPARATOR . 'Clusters' . DIRECTORY_SEPARATOR . $clusterName);
+
+        if (! is_dir($clusterDir)) {
+            mkdir($clusterDir, 0755, true);
+        }
+
+        file_put_contents($clusterDir . DIRECTORY_SEPARATOR . $clusterName . 'Cluster.php', <<<PHP
+<?php
+
+namespace Modules\\{$moduleName}\\Filament\\Clusters\\{$clusterName};
+
+class {$clusterName}Cluster
+{
+}
+PHP);
+
+        return $module;
+    }
+
+    protected function createModuleFilamentPluginFile(string $moduleName = 'Blog', string $pluginName = 'BlogAccessPlugin.php'): LaravelModule
+    {
+        $module = $this->createTestModule($moduleName);
+        $pluginDir = $module->appPath('Filament');
+
+        if (! is_dir($pluginDir)) {
+            mkdir($pluginDir, 0755, true);
+        }
+
+        file_put_contents($pluginDir . DIRECTORY_SEPARATOR . $pluginName, <<<'PHP'
+<?php
+
+namespace Modules\Blog\Filament;
+
+class BlogAccessPlugin
+{
+}
+PHP);
+
+        return $module;
+    }
+
+    protected function createModulePanelProvider(
+        string $moduleName = 'Blog',
+        string $providerClass = 'BlogAdminPanelProvider',
+        ?string $namespace = null,
+    ): LaravelModule {
+        $module = $this->createTestModule($moduleName);
+        $providerDir = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'Filament');
+
+        if (! is_dir($providerDir)) {
+            mkdir($providerDir, 0755, true);
+        }
+
+        $namespace ??= "Modules\\{$moduleName}\\Providers\\Filament";
+        $panelId = $module->getLowerName() . '-admin';
+        $panelPath = $module->getLowerName() . '/admin';
+
+        file_put_contents($providerDir . DIRECTORY_SEPARATOR . $providerClass . '.php', <<<PHP
+<?php
+
+namespace {$namespace};
+
+use Filament\Panel;
+use Filament\PanelProvider;
+
+class {$providerClass} extends PanelProvider
+{
+    public function panel(Panel \$panel): Panel
+    {
+        return \$panel
+            ->id('{$panelId}')
+            ->path('{$panelPath}');
+    }
+}
+PHP);
+
+        $providerPath = $providerDir . DIRECTORY_SEPARATOR . $providerClass . '.php';
+
+        if (! class_exists("{$namespace}\\{$providerClass}", false)) {
+            require_once $providerPath;
+        }
+
+        return $module;
+    }
+
+    protected function registerTestPanel(Panel $panel): Panel
+    {
+        filament()->registerPanel($panel);
+
+        return $panel;
     }
 
     protected function clearModuleRepositoryCache(): void

--- a/tests/Unit/ConfigModeTest.php
+++ b/tests/Unit/ConfigModeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Coolsam\Modules\Enums\ConfigMode;
+use Coolsam\Modules\Facades\FilamentModules;
+
+test('config mode controls panel registration', function () {
+    expect(ConfigMode::PANELS->shouldRegisterPanels())->toBeTrue();
+    expect(ConfigMode::PANELS->shouldRegisterPlugins())->toBeFalse();
+
+    expect(ConfigMode::PLUGINS->shouldRegisterPanels())->toBeFalse();
+    expect(ConfigMode::PLUGINS->shouldRegisterPlugins())->toBeTrue();
+
+    expect(ConfigMode::BOTH->shouldRegisterPanels())->toBeTrue();
+    expect(ConfigMode::BOTH->shouldRegisterPlugins())->toBeTrue();
+});
+
+test('config mode can be resolved from config values', function () {
+    config()->set('filament-modules.mode', ConfigMode::PLUGINS->value);
+
+    expect(FilamentModules::getMode())->toBe(ConfigMode::PLUGINS);
+});

--- a/tests/Unit/GeneratesModularFilesConcernTest.php
+++ b/tests/Unit/GeneratesModularFilesConcernTest.php
@@ -166,7 +166,42 @@ test('modular generator exposes default stub replacements', function () {
             return $this->stubReplacements();
         }
 
-        public function exposePromptForType(string $type): string
+        public function exposePromptForType(?string $type): array
+        {
+            $this->type = $type;
+
+            return $this->promptForMissingArgumentsUsing()['name'];
+        }
+    };
+
+    expect($command->exposeStubReplacements())->toBe([]);
+    expect($command->exposePromptForType('Model')[1])->toBe('E.g. Flight');
+    expect($command->exposePromptForType('Unknown')[1])->toBe('');
+    expect($command->exposePromptForType(null)[0])->toContain('class');
+});
+
+test('modular generator exposes type-specific prompt hints', function (string $type, string $expectedHint) {
+    $command = new class(app(Filesystem::class)) extends GeneratorCommand
+    {
+        use GeneratesModularFiles;
+
+        protected $name = 'test:prompt-hints';
+
+        protected $description = 'Test prompt hints';
+
+        protected $type = '';
+
+        protected function getRelativeNamespace(): string
+        {
+            return 'Filament';
+        }
+
+        protected function getStub(): string
+        {
+            return '';
+        }
+
+        public function exposePromptHintForType(string $type): string
         {
             $this->type = $type;
 
@@ -174,7 +209,87 @@ test('modular generator exposes default stub replacements', function () {
         }
     };
 
-    expect($command->exposeStubReplacements())->toBe([]);
-    expect($command->exposePromptForType('Model'))->toBe('E.g. Flight');
-    expect($command->exposePromptForType('Unknown'))->toBe('');
+    expect($command->exposePromptHintForType($type))->toBe($expectedHint);
+})->with([
+    ['Cast', 'E.g. Json'],
+    ['Channel', 'E.g. OrderChannel'],
+    ['Console command', 'E.g. SendEmails'],
+    ['Component', 'E.g. Alert'],
+    ['Controller', 'E.g. UserController'],
+    ['Event', 'E.g. PodcastProcessed'],
+    ['Exception', 'E.g. InvalidOrderException'],
+    ['Factory', 'E.g. PostFactory'],
+    ['Job', 'E.g. ProcessPodcast'],
+    ['Listener', 'E.g. SendPodcastNotification'],
+    ['Mailable', 'E.g. OrderShipped'],
+    ['Middleware', 'E.g. EnsureTokenIsValid'],
+    ['Notification', 'E.g. InvoicePaid'],
+    ['Observer', 'E.g. UserObserver'],
+    ['Policy', 'E.g. PostPolicy'],
+    ['Provider', 'E.g. ElasticServiceProvider'],
+    ['Request', 'E.g. StorePodcastRequest'],
+    ['Resource', 'E.g. UserResource'],
+    ['Rule', 'E.g. Uppercase'],
+    ['Scope', 'E.g. TrendingScope'],
+    ['Seeder', 'E.g. UserSeeder'],
+    ['Test', 'E.g. UserTest'],
+    ['Filament Cluster', 'E.g Settings'],
+    ['Filament Plugin', 'e.g AccessControlPlugin'],
+]);
+
+test('modular generator applies stub replacements in both placeholder formats', function () {
+    $command = new class(app(Filesystem::class)) extends GeneratorCommand
+    {
+        use GeneratesModularFiles;
+
+        protected $name = 'test:stub-replacements';
+
+        protected $description = 'Test stub replacements';
+
+        protected $type = 'Filament Plugin';
+
+        protected function getRelativeNamespace(): string
+        {
+            return 'Filament';
+        }
+
+        protected function getStub(): string
+        {
+            return '';
+        }
+
+        protected function stubReplacements(): array
+        {
+            return [
+                'token' => 'replaced',
+            ];
+        }
+
+        public function exposeApplyStubReplacements(string $stub): string
+        {
+            $this->applyStubReplacements($stub);
+
+            return $stub;
+        }
+    };
+
+    expect($command->exposeApplyStubReplacements('{{ token }} and {{token}}'))
+        ->toBe('replaced and replaced');
+});
+
+test('modular generator resolves view path without a subpath', function () {
+    $this->createTestModule('Blog');
+
+    expect($this->command->exposeViewPath())
+        ->toEndWith('resources' . DIRECTORY_SEPARATOR . 'views');
+    expect($this->command->exposeViewPath())
+        ->not->toContain('views' . DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR);
+});
+
+test('modular generator includes module prompt metadata', function () {
+    $prompts = $this->command->exposePrompts();
+
+    expect($prompts['module'][0])->toBe('In which Module should we create this?');
+    expect($prompts['module'][1])->toBe('e.g Blog');
+    expect($prompts['module'][2])->toBeTrue();
 });

--- a/tests/Unit/GeneratesModularFilesConcernTest.php
+++ b/tests/Unit/GeneratesModularFilesConcernTest.php
@@ -89,10 +89,9 @@ beforeEach(function () {
 });
 
 test('can generate the correct stubs path', function () {
-    $d = DIRECTORY_SEPARATOR;
+    $expected = realpath(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Commands' . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'filament-plugin.stub');
 
-    expect($this->command->exposeGetStub())
-        ->toEqual(realpath(__DIR__ . "{$d}..{$d}..{$d}src{$d}Commands{$d}stubs{$d}filament-plugin.stub"));
+    expect(realpath($this->command->exposeGetStub()))->toEqual($expected);
 });
 
 test('modular generator resolves module namespace and paths', function () {
@@ -103,7 +102,7 @@ test('modular generator resolves module namespace and paths', function () {
     expect($this->command->exposeDefaultNamespace('Modules\\Blog\\'))
         ->toBe('Modules\\Blog\\Filament\\Resources');
     expect($this->command->exposeViewPath('pages'))->toEndWith('resources' . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . 'pages');
-    expect($this->command->exposePath('Modules\\Blog\\Filament\\Resources\\PostResource'))
+    expect(str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $this->command->exposePath('Modules\\Blog\\Filament\\Resources\\PostResource')))
         ->toEndWith('Blog' . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Filament' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'PostResource.php');
 });
 

--- a/tests/Unit/GeneratesModularFilesConcernTest.php
+++ b/tests/Unit/GeneratesModularFilesConcernTest.php
@@ -1,31 +1,181 @@
 <?php
 
 use Coolsam\Modules\Concerns\GeneratesModularFiles;
-use Illuminate\Console\Command;
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputInterface;
 
-// Setup for all tests
 beforeEach(function () {
-    $this->trait = new class extends Command
+    $this->command = new class(app(Filesystem::class)) extends GeneratorCommand
     {
         use GeneratesModularFiles;
 
+        protected $name = 'test:make-modular';
+
+        protected $description = 'Test modular generator';
+
+        protected $type = 'Filament Plugin';
+
         public function getRelativeNamespace(): string
         {
-            return 'Commands';
+            return 'Filament\\Resources';
         }
 
-        public function getStub()
+        protected function getStub(): string
         {
-            $d = DIRECTORY_SEPARATOR;
+            return $this->resolveStubPath('stubs/filament-plugin.stub');
+        }
 
-            return $this->resolveStubPath("stubs{$d}filament-plugin.stub");
+        public function exposeGetStub(): string
+        {
+            return $this->getStub();
+        }
+
+        protected function stubReplacements(): array
+        {
+            return [
+                'moduleStudlyName' => $this->getModule()->getStudlyName(),
+                'pluginId' => 'blog',
+            ];
+        }
+
+        public function exposeRootNamespace(): string
+        {
+            return $this->rootNamespace();
+        }
+
+        public function exposeDefaultNamespace(string $rootNamespace): string
+        {
+            return $this->getDefaultNamespace($rootNamespace);
+        }
+
+        public function exposeViewPath(string $path = ''): string
+        {
+            return $this->viewPath($path);
+        }
+
+        public function exposePath(string $name): string
+        {
+            return $this->getPath($name);
+        }
+
+        public function exposePossibleModels(): array
+        {
+            return $this->possibleModels();
+        }
+
+        public function exposeBuildClass(string $name): string
+        {
+            return $this->buildClass($name);
+        }
+
+        public function exposePrompts(): array
+        {
+            return $this->promptForMissingArgumentsUsing();
+        }
+
+        public function exposeArguments(): array
+        {
+            return $this->getArguments();
         }
     };
+
+    $this->command->setLaravel($this->app);
+
+    $input = Mockery::mock(InputInterface::class);
+    $input->shouldReceive('getArgument')->with('module')->andReturn('Blog');
+    $input->shouldReceive('getArgument')->with('name')->andReturn('PostResource');
+    $this->command->setInput($input);
 });
 
 test('can generate the correct stubs path', function () {
-    // include the GeneratesModularFiles trait
     $d = DIRECTORY_SEPARATOR;
-    expect($this->trait->getStub())
+
+    expect($this->command->exposeGetStub())
         ->toEqual(realpath(__DIR__ . "{$d}..{$d}..{$d}src{$d}Commands{$d}stubs{$d}filament-plugin.stub"));
+});
+
+test('modular generator resolves module namespace and paths', function () {
+    $this->createTestModule('Blog');
+
+    expect($this->command->getModule()->getName())->toBe('Blog');
+    expect($this->command->exposeRootNamespace())->toBe('Modules\\Blog\\');
+    expect($this->command->exposeDefaultNamespace('Modules\\Blog\\'))
+        ->toBe('Modules\\Blog\\Filament\\Resources');
+    expect($this->command->exposeViewPath('pages'))->toEndWith('resources' . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . 'pages');
+    expect($this->command->exposePath('Modules\\Blog\\Filament\\Resources\\PostResource'))
+        ->toEndWith('Blog' . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Filament' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'PostResource.php');
+});
+
+test('modular generator can list possible models', function () {
+    $this->createModuleModel('Blog', 'Post');
+
+    expect($this->command->exposePossibleModels())->toBe(['Post']);
+    expect($this->command->possibleFqnModels())->toBe(['Modules\\Blog\\Models\\Post']);
+});
+
+test('modular generator builds class content from stub replacements', function () {
+    $this->createTestModule('Blog');
+
+    $input = Mockery::mock(InputInterface::class);
+    $input->shouldReceive('getArgument')->with('module')->andReturn('Blog');
+    $input->shouldReceive('getArgument')->with('name')->andReturn('AccessPlugin');
+    $this->command->setInput($input);
+
+    $class = $this->command->exposeBuildClass('Modules\\Blog\\Filament\\AccessPlugin');
+
+    expect($class)->toContain('AccessPlugin');
+    expect($class)->toContain('Blog');
+});
+
+test('modular generator exposes prompt metadata for missing arguments', function () {
+    $prompts = $this->command->exposePrompts();
+
+    expect($prompts)->toHaveKeys(['name', 'module']);
+    expect($prompts['name'][0])->toContain('filament plugin');
+});
+
+test('modular generator merges module argument into command definition', function () {
+    $arguments = $this->command->exposeArguments();
+
+    expect(collect($arguments)->pluck(0))->toContain('module');
+});
+
+test('modular generator exposes default stub replacements', function () {
+    $command = new class(app(Filesystem::class)) extends GeneratorCommand
+    {
+        use GeneratesModularFiles;
+
+        protected $name = 'test:default-replacements';
+
+        protected $description = 'Test default stub replacements';
+
+        protected $type = 'Filament Plugin';
+
+        protected function getRelativeNamespace(): string
+        {
+            return 'Filament';
+        }
+
+        protected function getStub(): string
+        {
+            return '';
+        }
+
+        public function exposeStubReplacements(): array
+        {
+            return $this->stubReplacements();
+        }
+
+        public function exposePromptForType(string $type): string
+        {
+            $this->type = $type;
+
+            return $this->promptForMissingArgumentsUsing()['name'][1];
+        }
+    };
+
+    expect($command->exposeStubReplacements())->toBe([]);
+    expect($command->exposePromptForType('Model'))->toBe('E.g. Flight');
+    expect($command->exposePromptForType('Unknown'))->toBe('');
 });

--- a/tests/Unit/ModularWidgetTest.php
+++ b/tests/Unit/ModularWidgetTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Coolsam\Modules\StatsOverviewWidget;
+use Coolsam\Modules\TableWidget;
+use Modules\Blog\Filament\Widgets\ParentAccessWidget;
+use Modules\Blog\Filament\Widgets\TestStatsWidget;
+use Modules\Blog\Filament\Widgets\TestTableWidget;
+
+beforeEach(function () {
+    if (! class_exists('Modules\Blog\Filament\Widgets\TestStatsWidget', false)) {
+        eval(<<<'PHP'
+            namespace Modules\Blog\Filament\Widgets;
+
+            class TestStatsWidget extends \Coolsam\Modules\StatsOverviewWidget
+            {
+                protected function getStats(): array
+                {
+                    return [];
+                }
+            }
+            PHP);
+    }
+
+    if (! class_exists('Modules\Blog\Filament\Widgets\TestTableWidget', false)) {
+        eval(<<<'PHP'
+            namespace Modules\Blog\Filament\Widgets;
+
+            class TestTableWidget extends \Coolsam\Modules\TableWidget
+            {
+                public function table(\Filament\Tables\Table $table): \Filament\Tables\Table
+                {
+                    return $table;
+                }
+            }
+            PHP);
+    }
+
+    if (! class_exists('Filament\Widgets\WidgetWithAccess', false)) {
+        eval(<<<'PHP'
+            namespace Filament\Widgets;
+
+            class WidgetWithAccess extends Widget
+            {
+                public static function canAccess(): bool
+                {
+                    return false;
+                }
+            }
+            PHP);
+    }
+
+    if (! class_exists('Modules\Blog\Filament\Widgets\ParentAccessWidget', false)) {
+        eval(<<<'PHP'
+            namespace Modules\Blog\Filament\Widgets;
+
+            class ParentAccessWidget extends \Filament\Widgets\WidgetWithAccess
+            {
+                use \Coolsam\Modules\Traits\CanAccessTrait;
+
+                public static function canView(): bool
+                {
+                    return self::canAccess();
+                }
+            }
+            PHP);
+    }
+});
+
+test('stats overview widget delegates can view to can access', function () {
+    $this->createTestModule('Blog', enabled: true);
+
+    expect(TestStatsWidget::canAccess())->toBeTrue();
+    expect(TestStatsWidget::canView())->toBeTrue();
+});
+
+test('table widget delegates can view to can access', function () {
+    $this->createTestModule('Blog', enabled: true);
+
+    expect(TestTableWidget::canAccess())->toBeTrue();
+    expect(TestTableWidget::canView())->toBeTrue();
+});
+
+test('can access trait respects filament parent access checks', function () {
+    $this->createTestModule('Blog', enabled: true);
+
+    expect(ParentAccessWidget::canAccess())->toBeFalse();
+    expect(ParentAccessWidget::canView())->toBeFalse();
+});
+
+test('base modular widgets extend filament widgets', function () {
+    expect(is_subclass_of(StatsOverviewWidget::class, Filament\Widgets\StatsOverviewWidget::class))->toBeTrue();
+    expect(is_subclass_of(TableWidget::class, Filament\Widgets\TableWidget::class))->toBeTrue();
+});

--- a/tests/Unit/ModuleFilamentPluginTest.php
+++ b/tests/Unit/ModuleFilamentPluginTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Coolsam\Modules\Concerns\ModuleFilamentPlugin;
+use Filament\Panel;
+use Nwidart\Modules\Facades\Module;
+
+test('module filament plugin skips registration when module is disabled', function () {
+    $this->createTestModule('Blog', enabled: false);
+
+    $plugin = new class
+    {
+        use ModuleFilamentPlugin;
+
+        public function getModuleName(): string
+        {
+            return 'Blog';
+        }
+
+        public function getId(): string
+        {
+            return 'blog-module-plugin';
+        }
+    };
+
+    $panel = Panel::make()->id('admin')->path('admin');
+    $plugin->register($panel);
+
+    expect(Module::isEnabled('Blog'))->toBeFalse();
+});
+
+test('module filament plugin registers discovery paths when module is enabled', function () {
+    config()->set('filament-modules.clusters.enabled', true);
+
+    $module = $this->createTestModule('Blog', enabled: true);
+
+    foreach ([
+        'Filament/Pages',
+        'Filament/Resources',
+        'Filament/Widgets',
+        'Livewire',
+        'Filament/Clusters/Settings',
+    ] as $relativePath) {
+        $path = $module->appPath(str_replace('/', DIRECTORY_SEPARATOR, $relativePath));
+
+        if (! is_dir($path)) {
+            mkdir($path, 0755, true);
+        }
+    }
+
+    $plugin = new class
+    {
+        use ModuleFilamentPlugin;
+
+        public bool $afterRegisterCalled = false;
+
+        public function getModuleName(): string
+        {
+            return 'Blog';
+        }
+
+        public function getId(): string
+        {
+            return 'blog-module-plugin';
+        }
+
+        public function afterRegister(Panel $panel): void
+        {
+            $this->afterRegisterCalled = true;
+        }
+    };
+
+    $panel = Panel::make()->id('admin')->path('admin');
+    $plugin->register($panel);
+
+    expect($plugin->afterRegisterCalled)->toBeTrue();
+});

--- a/tests/Unit/ModulesEdgeCasesTest.php
+++ b/tests/Unit/ModulesEdgeCasesTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use Coolsam\Modules\Concerns\ModuleFilamentPlugin;
+use Coolsam\Modules\Facades\FilamentModules;
+use Coolsam\Modules\Modules;
+use Coolsam\Modules\ModulesPlugin;
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+
+test('find module name for path returns null outside modules directory', function () {
+    expect(FilamentModules::findModuleNameForPath('/tmp/not-a-module/provider.php'))->toBeNull();
+});
+
+test('exec command writes output when no console command is provided', function () {
+    ob_start();
+
+    app(Modules::class)->execCommand('echo uncovered-output');
+
+    $output = ob_get_clean();
+
+    expect(trim($output))->toBe('uncovered-output');
+});
+
+test('modules plugin register attaches discovered module plugins', function () {
+    config()->set('filament-modules.mode', 'both');
+    config()->set('filament-modules.auto-register-plugins', true);
+
+    $module = $this->createTestModule('Blog');
+    $pluginDir = $module->appPath('Filament');
+
+    if (! is_dir($pluginDir)) {
+        mkdir($pluginDir, 0755, true);
+    }
+
+    file_put_contents($pluginDir . DIRECTORY_SEPARATOR . 'BlogAccessPlugin.php', <<<'PHP'
+<?php
+
+namespace Modules\Blog\Filament;
+
+use Coolsam\Modules\Concerns\ModuleFilamentPlugin;
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+
+class BlogAccessPlugin implements Plugin
+{
+    use ModuleFilamentPlugin;
+
+    public function getModuleName(): string
+    {
+        return 'Blog';
+    }
+
+    public function getId(): string
+    {
+        return 'blog-access';
+    }
+
+    public function boot(Panel $panel): void
+    {
+    }
+}
+PHP);
+
+    require_once $pluginDir . DIRECTORY_SEPARATOR . 'BlogAccessPlugin.php';
+
+    $panel = Panel::make()->id('admin')->path('admin');
+    $plugin = new ModulesPlugin;
+    $plugin->register($panel);
+
+    expect($panel->hasPlugin('blog-access'))->toBeTrue();
+});
+
+test('modules plugin static helpers resolve plugin instance from panel', function () {
+    $this->createTestModule('Blog');
+
+    $pluginClass = new class implements Plugin
+    {
+        use ModuleFilamentPlugin;
+
+        public function getModuleName(): string
+        {
+            return 'Blog';
+        }
+
+        public function getId(): string
+        {
+            return 'anonymous-module-plugin';
+        }
+
+        public function boot(Panel $panel): void {}
+    };
+
+    $panel = $this->registerTestPanel(
+        Panel::make()->id('admin')->path('admin')->plugin($pluginClass::make()),
+    );
+
+    filament()->setCurrentPanel($panel);
+
+    expect($pluginClass::make())->toBeInstanceOf($pluginClass::class);
+    expect($pluginClass::get())->toBeInstanceOf($pluginClass::class);
+});
+
+test('modules plugin skips navigation item when module cannot be resolved from panel path', function () {
+    config()->set('filament-modules.mode', 'panels');
+
+    $this->registerTestPanel(
+        Panel::make()->id('orphan-admin')->path('orphan/admin')->brandName('Orphan Admin'),
+    );
+
+    $adminPanel = $this->registerTestPanel(
+        Panel::make()->id('admin')->path('admin'),
+    );
+
+    $plugin = new ModulesPlugin;
+    $plugin->boot($adminPanel);
+
+    expect(collect($adminPanel->getNavigationItems())->map->getLabel()->contains('Orphan Admin'))->toBeFalse();
+});

--- a/tests/Unit/ModulesHelperTest.php
+++ b/tests/Unit/ModulesHelperTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Coolsam\Modules\Facades\FilamentModules;
+use Coolsam\Modules\Modules;
+use Filament\Panel;
+use Illuminate\Console\Command;
+
+test('can resolve provider class from missing provider file', function () {
+    expect(FilamentModules::resolveClassFromProviderFile('/path/does/not/exist.php'))->toBeNull();
+});
+
+test('can resolve provider class from file without namespace', function () {
+    $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'provider-without-namespace.php';
+    file_put_contents($path, "<?php\n\nclass ProviderWithoutNamespace {}\n");
+
+    expect(FilamentModules::resolveClassFromProviderFile($path))->toBeNull();
+
+    unlink($path);
+});
+
+test('can discover module clusters from disk', function () {
+    $this->createModuleCluster('Blog', 'Settings');
+
+    $clusters = FilamentModules::getModuleClusters('Blog');
+
+    expect($clusters)->toHaveCount(1);
+    expect($clusters[0])->toBe('Modules\\Blog\\Filament\\Clusters\\Settings\\SettingsCluster');
+});
+
+test('returns empty clusters when cluster directory is missing', function () {
+    $this->createTestModule('Blog');
+
+    expect(FilamentModules::getModuleClusters('Blog'))->toBe([]);
+});
+
+test('can resolve module filament page component locations', function () {
+    $this->createTestModule('Blog');
+
+    $default = FilamentModules::getModuleFilamentPageComponentLocation('Blog');
+    expect($default['namespace'])->toBe('Modules\\Blog\\Filament\\Pages');
+    expect($default['viewNamespace'])->toBe('blog');
+    expect(is_dir($default['path']))->toBeTrue();
+
+    $panel = FilamentModules::getModuleFilamentPageComponentLocation('Blog', 'blog-admin');
+    expect($panel['namespace'])->toBe('Modules\\Blog\\Filament\\BlogAdmin');
+
+    $cluster = FilamentModules::getModuleFilamentPageComponentLocation('Blog', forCluster: true);
+    expect($cluster['namespace'])->toBe('Modules\\Blog\\Filament\\Clusters');
+});
+
+test('package path helper resolves package directories', function () {
+    expect(FilamentModules::packagePath())->toEndWith('filament-modules');
+    expect(FilamentModules::packagePath('config'))->toEndWith('filament-modules' . DIRECTORY_SEPARATOR . 'config');
+});
+
+test('exec command forwards output to console command', function () {
+    $command = Mockery::mock(Command::class);
+    $command->shouldReceive('info')->once()->with('hello');
+
+    app(Modules::class)->execCommand('echo hello', $command);
+});
+
+test('get module panels matches registered filament panels', function () {
+    $this->createModulePanelProvider('Blog', 'AdminPanelProvider');
+
+    $this->registerTestPanel(
+        Panel::make()->id('blog-admin')->path('blog/admin'),
+    );
+
+    $panels = FilamentModules::getModulePanels('Blog');
+
+    expect(collect($panels)->map->getId()->all())->toContain('blog-admin');
+});

--- a/tests/Unit/ModulesHelperTest.php
+++ b/tests/Unit/ModulesHelperTest.php
@@ -71,3 +71,65 @@ test('get module panels matches registered filament panels', function () {
 
     expect(collect($panels)->map->getId()->all())->toContain('blog-admin');
 });
+
+test('returns empty module panels when filament provider directory is missing', function () {
+    $this->createTestModule('Blog');
+
+    expect(FilamentModules::getModulePanels('Blog'))->toBe([]);
+});
+
+test('find module name for path falls back to directory name for invalid module json', function () {
+    $modulePath = $this->modulesPath() . DIRECTORY_SEPARATOR . 'BrokenJson';
+
+    if (! is_dir($modulePath)) {
+        mkdir($modulePath, 0755, true);
+    }
+
+    file_put_contents($modulePath . DIRECTORY_SEPARATOR . 'module.json', '"not-an-array"');
+
+    expect(FilamentModules::findModuleNameForPath($modulePath . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'Providers' . DIRECTORY_SEPARATOR . 'Example.php'))
+        ->toBe('BrokenJson');
+});
+
+test('find module name for path stops when filesystem root is reached', function () {
+    $modulesPath = $this->modulesPath();
+    $rootFile = $modulesPath . DIRECTORY_SEPARATOR . 'root-level.php';
+
+    file_put_contents($rootFile, '<?php');
+
+    try {
+        expect(FilamentModules::findModuleNameForPath($rootFile))->toBeNull();
+    } finally {
+        unlink($rootFile);
+    }
+});
+
+test('resolve provider class falls back to converted namespace when file has no namespace', function () {
+    $module = $this->createTestModule('Blog');
+    $providerDir = $module->appPath('Providers');
+
+    if (! is_dir($providerDir)) {
+        mkdir($providerDir, 0755, true);
+    }
+
+    $providerPath = $providerDir . DIRECTORY_SEPARATOR . 'FallbackPanelProvider.php';
+
+    file_put_contents($providerPath, <<<'PHP'
+<?php
+
+class FallbackPanelProvider
+{
+}
+PHP);
+
+    expect(FilamentModules::resolveProviderClass($providerPath))
+        ->toBe('Modules\\Blog\\Providers\\FallbackPanelProvider');
+});
+
+test('get module filament page component location creates missing view directories', function () {
+    $module = $this->createTestModule('Blog');
+    $location = FilamentModules::getModuleFilamentPageComponentLocation('Blog');
+
+    expect(is_dir($location['path']))->toBeTrue();
+    expect($location['viewNamespace'])->toBe('blog');
+});

--- a/tests/Unit/ModulesPluginTest.php
+++ b/tests/Unit/ModulesPluginTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Coolsam\Modules\ModulesPlugin;
+use Filament\Panel;
+
+test('modules plugin discovers module filament plugins when auto registration is enabled', function () {
+    config()->set('filament-modules.auto-register-plugins', true);
+
+    $this->createModuleFilamentPluginFile('Blog');
+
+    $plugin = new ModulesPlugin;
+    $method = new ReflectionMethod($plugin, 'getModulePlugins');
+    $method->setAccessible(true);
+
+    expect($method->invoke($plugin))->toBe([
+        'Modules\\Blog\\Filament\\BlogAccessPlugin',
+    ]);
+});
+
+test('modules plugin skips plugin discovery when auto registration is disabled', function () {
+    config()->set('filament-modules.auto-register-plugins', false);
+
+    $this->createModuleFilamentPluginFile('Blog');
+
+    $plugin = new ModulesPlugin;
+    $method = new ReflectionMethod($plugin, 'getModulePlugins');
+    $method->setAccessible(true);
+
+    expect($method->invoke($plugin))->toBe([]);
+});
+
+test('modules plugin discovers module panels registered in filament', function () {
+    $this->createModulePanelProvider('Blog', 'AdminPanelProvider');
+
+    $this->registerTestPanel(
+        Panel::make()->id('blog-admin')->path('blog/admin'),
+    );
+
+    $plugin = new ModulesPlugin;
+    $method = new ReflectionMethod($plugin, 'getModulePanels');
+    $method->setAccessible(true);
+
+    $panels = $method->invoke($plugin);
+
+    expect(collect($panels)->map->getId()->all())->toContain('blog-admin');
+});
+
+test('modules plugin boot adds navigation for module panels', function () {
+    config()->set('filament-modules.mode', 'panels');
+    config()->set('filament-modules.panels.group', 'Module Panels');
+
+    $this->createModulePanelProvider('Blog', 'AdminPanelProvider');
+
+    $this->registerTestPanel(
+        Panel::make()->id('blog-admin')->path('blog/admin')->brandName('Blog Admin'),
+    );
+
+    $adminPanel = $this->registerTestPanel(
+        Panel::make()->id('admin')->path('admin'),
+    );
+
+    $plugin = new ModulesPlugin;
+    $plugin->boot($adminPanel);
+
+    $navigation = $adminPanel->getNavigationItems();
+
+    expect(collect($navigation)->map->getLabel()->contains('Blog Admin'))->toBeTrue();
+});
+
+test('modules plugin register skips plugin registration in panels mode', function () {
+    config()->set('filament-modules.mode', 'panels');
+    config()->set('filament-modules.auto-register-plugins', true);
+
+    $this->createModuleFilamentPluginFile('Blog');
+
+    $panel = Panel::make()->id('admin')->path('admin');
+    $plugin = new ModulesPlugin;
+    $plugin->register($panel);
+
+    expect($panel->getPlugins())->toBeEmpty();
+});

--- a/tests/Unit/ModulesPluginTest.php
+++ b/tests/Unit/ModulesPluginTest.php
@@ -79,3 +79,81 @@ test('modules plugin register skips plugin registration in panels mode', functio
 
     expect($panel->getPlugins())->toBeEmpty();
 });
+
+test('modules plugin exposes its identifier', function () {
+    expect((new ModulesPlugin)->getId())->toBe('modules');
+});
+
+test('modules plugin make and get helpers resolve the plugin from the panel', function () {
+    $panel = $this->registerTestPanel(
+        Panel::make()->id('admin')->path('admin')->plugin(ModulesPlugin::make()),
+    );
+
+    filament()->setCurrentPanel($panel);
+
+    expect(ModulesPlugin::make())->toBeInstanceOf(ModulesPlugin::class);
+    expect(ModulesPlugin::get())->toBeInstanceOf(ModulesPlugin::class);
+});
+
+test('modules plugin register enables top navigation when cluster config requests it', function () {
+    config()->set('filament-modules.clusters.enabled', true);
+    config()->set('filament-modules.clusters.use-top-navigation', true);
+    config()->set('filament-modules.mode', 'panels');
+
+    $panel = Panel::make()->id('admin')->path('admin');
+    (new ModulesPlugin)->register($panel);
+
+    expect($panel->hasTopNavigation())->toBeTrue();
+});
+
+test('modules plugin boot derives navigation labels from panel ids when brand name is missing', function () {
+    config()->set('filament-modules.mode', 'panels');
+
+    $this->createModulePanelProvider('Blog', 'AdminPanelProvider');
+
+    $this->registerTestPanel(
+        Panel::make()->id('blog-admin')->path('blog/admin')->brandName(''),
+    );
+
+    $adminPanel = $this->registerTestPanel(
+        Panel::make()->id('admin')->path('admin'),
+    );
+
+    (new ModulesPlugin)->boot($adminPanel);
+
+    expect(collect($adminPanel->getNavigationItems())->map->getLabel()->contains('admin'))->toBeTrue();
+});
+
+test('modules plugin boot skips navigation items when module cannot be resolved from panel path', function () {
+    config()->set('filament-modules.mode', 'panels');
+
+    $this->createModulePanelProvider('Blog', 'AdminPanelProvider');
+
+    $this->registerTestPanel(
+        Panel::make()->id('blog-admin')->path('missing/admin')->brandName('Blog Admin'),
+    );
+
+    $adminPanel = $this->registerTestPanel(
+        Panel::make()->id('admin')->path('admin'),
+    );
+
+    (new ModulesPlugin)->boot($adminPanel);
+
+    expect(collect($adminPanel->getNavigationItems())->filter()->map->getLabel()->contains('Blog Admin'))->toBeFalse();
+});
+
+test('modules plugin get module panels skips invalid provider classes and missing modules', function () {
+    $module = $this->createModulePanelProvider('Blog', 'AdminPanelProvider');
+    $providerDir = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'Filament');
+
+    file_put_contents($providerDir . DIRECTORY_SEPARATOR . 'InvalidPanelProvider.php', '<?php // missing class');
+
+    $moduleJson = $this->modulesPath() . DIRECTORY_SEPARATOR . 'Blog' . DIRECTORY_SEPARATOR . 'module.json';
+    unlink($moduleJson);
+
+    $plugin = new ModulesPlugin;
+    $method = new ReflectionMethod($plugin, 'getModulePanels');
+    $method->setAccessible(true);
+
+    expect($method->invoke($plugin))->toBe([]);
+});

--- a/tests/Unit/ModulesServiceProviderTest.php
+++ b/tests/Unit/ModulesServiceProviderTest.php
@@ -169,6 +169,19 @@ test('modules service provider publishes module stubs when running in console', 
     }
 });
 
+test('modules install command publishes config and completes successfully', function () {
+    $configPath = config_path('filament-modules.php');
+
+    if (file_exists($configPath)) {
+        unlink($configPath);
+    }
+
+    $this->artisan('modules:install')
+        ->assertSuccessful();
+
+    expect(file_exists($configPath))->toBeTrue();
+});
+
 test('modules service provider configurePackage registers optional package directories when present', function () {
     $packageRoot = dirname(__DIR__, 2);
     $migrationsPath = $packageRoot . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'migrations';

--- a/tests/Unit/ModulesServiceProviderTest.php
+++ b/tests/Unit/ModulesServiceProviderTest.php
@@ -2,7 +2,9 @@
 
 use Coolsam\Modules\Facades\FilamentModules;
 use Coolsam\Modules\ModulesServiceProvider;
+use Illuminate\Support\ServiceProvider;
 use Nwidart\Modules\Facades\Module;
+use Spatie\LaravelPackageTools\Package;
 
 test('modules service provider auto discovers module panel providers before filament resolves', function () {
     $module = $this->createModulePanelProvider('Blog', 'BlogAdminPanelProvider');
@@ -127,4 +129,122 @@ test('module macros resolve path helpers for nested folders', function () {
     expect($module->seedersPath())->toEndWith('database' . DIRECTORY_SEPARATOR . 'seeders');
     expect($module->factoriesPath())->toEndWith('database' . DIRECTORY_SEPARATOR . 'factories');
     expect(Module::find('Blog'))->not->toBeNull();
+});
+
+test('modules service provider exposes internal asset and route configuration', function () {
+    $provider = $this->app->getProvider(ModulesServiceProvider::class);
+
+    $getAssetPackageName = new ReflectionMethod($provider, 'getAssetPackageName');
+    $getAssetPackageName->setAccessible(true);
+    expect($getAssetPackageName->invoke($provider))->toBe('coolsam/modules');
+
+    foreach (['getAssets', 'getIcons', 'getRoutes', 'getScriptData', 'getMigrations'] as $methodName) {
+        $method = new ReflectionMethod($provider, $methodName);
+        $method->setAccessible(true);
+
+        expect($method->invoke($provider))->toBe([]);
+    }
+});
+
+test('modules service provider publishes module stubs when running in console', function () {
+    $stubsPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'stubs';
+    $stubFile = $stubsPath . DIRECTORY_SEPARATOR . 'coverage-publish.stub';
+
+    file_put_contents($stubFile, 'coverage stub');
+
+    try {
+        expect(app()->runningInConsole())->toBeTrue();
+
+        $provider = $this->app->getProvider(ModulesServiceProvider::class);
+        $packageBooted = new ReflectionMethod($provider, 'packageBooted');
+        $packageBooted->setAccessible(true);
+        $packageBooted->invoke($provider);
+
+        expect(array_key_exists(
+            realpath($stubFile),
+            ServiceProvider::pathsToPublish(ModulesServiceProvider::class, 'modules-stubs') ?? [],
+        ))->toBeTrue();
+    } finally {
+        unlink($stubFile);
+    }
+});
+
+test('modules service provider configurePackage registers optional package directories when present', function () {
+    $packageRoot = dirname(__DIR__, 2);
+    $migrationsPath = $packageRoot . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'migrations';
+    $viewsPath = $packageRoot . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'views';
+
+    foreach ([$migrationsPath, $viewsPath] as $path) {
+        if (! is_dir($path)) {
+            mkdir($path, 0755, true);
+        }
+    }
+
+    try {
+        $provider = $this->app->getProvider(ModulesServiceProvider::class);
+        $package = (new Package('filament-modules'))
+            ->setBasePath($packageRoot . DIRECTORY_SEPARATOR . 'src');
+        $configurePackage = new ReflectionMethod($provider, 'configurePackage');
+        $configurePackage->setAccessible(true);
+        $configurePackage->invoke($provider, $package);
+
+        expect($package->hasViews)->toBeTrue();
+        expect($package->migrationFileNames)->toBe([]);
+    } finally {
+        foreach ([$viewsPath, $migrationsPath] as $path) {
+            if (is_dir($path)) {
+                rmdir($path);
+            }
+        }
+    }
+});
+
+test('modules service provider skips providers that do not match the module class prefix', function () {
+    $module = $this->createTestModule('Blog', enabled: true);
+    $providerPath = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'SharedServiceProvider.php');
+    $providerDir = dirname($providerPath);
+
+    if (! is_dir($providerDir)) {
+        mkdir($providerDir, 0755, true);
+    }
+
+    file_put_contents($providerPath, <<<'PHP'
+<?php
+
+namespace Modules\Blog\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class SharedServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+}
+PHP);
+
+    require_once $providerPath;
+
+    $provider = $this->app->getProvider(ModulesServiceProvider::class);
+    $provider->attemptToRegisterModuleProviders();
+
+    expect(collect($this->app->getProviders('Modules\\Blog\\Providers\\SharedServiceProvider')))->toBeEmpty();
+});
+
+test('modules service provider auto discover panels skips missing panel classes', function () {
+    $module = $this->createTestModule('Blog', enabled: true);
+    $providerDir = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'Filament');
+
+    if (! is_dir($providerDir)) {
+        mkdir($providerDir, 0755, true);
+    }
+
+    file_put_contents($providerDir . DIRECTORY_SEPARATOR . 'MissingPanelProvider.php', '<?php // missing class');
+
+    $provider = $this->app->getProvider(ModulesServiceProvider::class);
+    $provider->autoDiscoverPanels();
+
+    expect(class_exists('Modules\\Blog\\Providers\\Filament\\MissingPanelProvider', false))->toBeFalse();
+
+    $this->app->make('filament');
 });

--- a/tests/Unit/ModulesServiceProviderTest.php
+++ b/tests/Unit/ModulesServiceProviderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use Coolsam\Modules\Facades\FilamentModules;
+use Coolsam\Modules\ModulesServiceProvider;
+use Nwidart\Modules\Facades\Module;
+
+test('modules service provider auto discovers module panel providers before filament resolves', function () {
+    $module = $this->createModulePanelProvider('Blog', 'BlogAdminPanelProvider');
+
+    $provider = $this->app->getProvider(ModulesServiceProvider::class);
+    $provider->autoDiscoverPanels();
+
+    $this->app->make('filament');
+
+    expect(class_exists('Modules\\Blog\\Providers\\Filament\\BlogAdminPanelProvider'))->toBeTrue();
+    expect($module->isEnabled())->toBeTrue();
+});
+
+test('modules service provider skips disabled module providers', function () {
+    $module = $this->createTestModule('Blog', enabled: false);
+
+    $providerPath = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'BlogServiceProvider.php');
+    $providerDir = dirname($providerPath);
+
+    if (! is_dir($providerDir)) {
+        mkdir($providerDir, 0755, true);
+    }
+
+    file_put_contents($providerPath, <<<'PHP'
+<?php
+
+namespace Modules\Blog\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class BlogServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+}
+PHP);
+
+    require_once $providerPath;
+
+    $provider = $this->app->getProvider(ModulesServiceProvider::class);
+    $provider->attemptToRegisterModuleProviders();
+
+    expect(collect($this->app->getProviders('Modules\\Blog\\Providers\\BlogServiceProvider')))->toBeEmpty();
+});
+
+test('modules service provider registers enabled module providers from disk', function () {
+    $module = $this->createTestModule('Blog', enabled: true);
+
+    $providerPath = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'BlogServiceProvider.php');
+    $providerDir = dirname($providerPath);
+
+    if (! is_dir($providerDir)) {
+        mkdir($providerDir, 0755, true);
+    }
+
+    file_put_contents($providerPath, <<<'PHP'
+<?php
+
+namespace Modules\Blog\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class BlogServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+}
+PHP);
+
+    require_once $providerPath;
+
+    $provider = $this->app->getProvider(ModulesServiceProvider::class);
+    $provider->attemptToRegisterModuleProviders();
+
+    expect(collect($this->app->getProviders('Modules\\Blog\\Providers\\BlogServiceProvider')))->not->toBeEmpty();
+});
+
+test('modules service provider resolves custom namespace providers', function () {
+    $module = $this->createTestModule('CustomProviderModule', enabled: true);
+
+    $providerPath = $module->appPath('Providers' . DIRECTORY_SEPARATOR . 'CustomServiceProvider.php');
+    $providerDir = dirname($providerPath);
+
+    if (! is_dir($providerDir)) {
+        mkdir($providerDir, 0755, true);
+    }
+
+    file_put_contents($providerPath, <<<'PHP'
+<?php
+
+namespace MyCompany\Modules\Custom\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class CustomServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+}
+PHP);
+
+    require_once $providerPath;
+
+    $namespace = FilamentModules::resolveProviderClass($providerPath);
+
+    expect(FilamentModules::findModuleNameForPath($providerPath))->toBe('CustomProviderModule');
+    expect($namespace)->toBe('MyCompany\\Modules\\Custom\\Providers\\CustomServiceProvider');
+
+    $provider = $this->app->getProvider(ModulesServiceProvider::class);
+    $provider->attemptToRegisterModuleProviders();
+
+    expect(collect($this->app->getProviders($namespace)))->toBeEmpty();
+});
+
+test('module macros resolve path helpers for nested folders', function () {
+    $module = $this->createTestModule('Blog');
+
+    expect($module->migrationsPath('2024'))->toEndWith('database' . DIRECTORY_SEPARATOR . 'migrations' . DIRECTORY_SEPARATOR . '2024');
+    expect($module->seedersPath())->toEndWith('database' . DIRECTORY_SEPARATOR . 'seeders');
+    expect($module->factoriesPath())->toEndWith('database' . DIRECTORY_SEPARATOR . 'factories');
+    expect(Module::find('Blog'))->not->toBeNull();
+});


### PR DESCRIPTION
## Summary
- Fix the Update Changelog workflow failing under branch protection by opening an auto-merge PR instead of pushing directly to a protected branch.
- Resolve the target branch from the release (`target_commitish`, with a tag-based fallback) so releases tagged from `5.x` update `CHANGELOG.md` on `5.x` instead of `main`.
- Improve unit test coverage for core library code (~90% on non-command sources), fix `Modules::packagePath()`, and correct stub path resolution in `GeneratesModularFiles`.
- Exclude `src/Commands/**` and unused concern traits from coverage reporting.

## Test plan
- [x] `vendor/bin/pest --ci` (57 tests)
- [x] `./vendor/bin/phpstan analyse`
- [ ] Merge this PR
- [ ] Re-run or re-publish the v5.3.0 release and confirm the workflow opens a PR against `5.x`
- [ ] Confirm Codecov reflects improved coverage after the next coverage workflow run