### PR TITLE
fix: merge changelog PR when auto-merge is unavailable

### DIFF
--- a/.github/workflows/run-coverage.yml
+++ b/.github/workflows/run-coverage.yml
@@ -14,7 +14,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Code coverage
+    name: Code coverage · PHP 8.4 · Laravel 13
 
     steps:
       - name: Checkout code
@@ -33,8 +33,10 @@ jobs:
           COMPOSER_PROCESS_TIMEOUT: 0
         run: |
           composer require \
-            "laravel/framework:^12.0" \
-            "orchestra/testbench:^10.0" \
+            "laravel/framework:^13.10" \
+            "orchestra/testbench:^11.0" \
+            "pestphp/pest-plugin-laravel:^4.0" \
+            "pestphp/pest-plugin-livewire:^4.0" \
             --dev \
             --no-interaction \
             --no-update

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -66,8 +66,14 @@ jobs:
             Triggered by: ${{ github.event.release.html_url }}
           delete-branch: true
 
-      - name: Enable auto-merge
+      - name: Merge pull request
         if: steps.create-pull-request.outputs.pull-request-operation == 'created' || steps.create-pull-request.outputs.pull-request-operation == 'updated'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge "${{ steps.create-pull-request.outputs.pull-request-number }}" --auto --squash
+        run: |
+          PR="${{ steps.create-pull-request.outputs.pull-request-number }}"
+
+          # Auto-merge only works when required checks are still pending. Changelog PRs
+          # target branches without required status checks, so GitHub rejects --auto with
+          # "Pull request is in clean status" and the PR must be merged directly instead.
+          gh pr merge "$PR" --auto --squash || gh pr merge "$PR" --squash --delete-branch


### PR DESCRIPTION
## Summary
- Fixes post-release `update-changelog.yml` failure: `gh pr merge --auto --squash` errors with `Pull request is in clean status` when the changelog PR is immediately mergeable.
- This happens because `5.x` branch protection has no required status checks, so GitHub cannot queue auto-merge.
- The workflow now tries `--auto` first, then falls back to a direct squash merge with branch deletion.
- Aligns `run-coverage.yml` with the existing PHP 8.4 + Laravel 13 test matrix job.

## Test plan
- [ ] CI passes on this PR
- [ ] Merge this PR
- [ ] Cut a patch release and confirm the changelog workflow completes without the auto-merge step failing