### PR TITLE
ci: run coverage on PHP 8.4 and Laravel 13

### DIFF
--- a/.github/workflows/run-coverage.yml
+++ b/.github/workflows/run-coverage.yml
@@ -14,7 +14,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Code coverage
+    name: Code coverage · PHP 8.4 · Laravel 13
 
     steps:
       - name: Checkout code
@@ -33,8 +33,10 @@ jobs:
           COMPOSER_PROCESS_TIMEOUT: 0
         run: |
           composer require \
-            "laravel/framework:^12.0" \
-            "orchestra/testbench:^10.0" \
+            "laravel/framework:^13.10" \
+            "orchestra/testbench:^11.0" \
+            "pestphp/pest-plugin-laravel:^4.0" \
+            "pestphp/pest-plugin-livewire:^4.0" \
             --dev \
             --no-interaction \
             --no-update


### PR DESCRIPTION
## Summary
- Updates `run-coverage.yml` to use Laravel 13 + testbench 11 + Pest 4 plugins on PHP 8.4.
- The `run-tests.yml` matrix already includes `PHP 8.4 · Laravel ^13.10 · ubuntu-latest`; this aligns coverage with that stack.

## Test plan
- [ ] CI passes on this PR (run-tests + run-coverage)

Made with [Cursor](https://cursor.com)